### PR TITLE
Bit of a fix to ruby_parser

### DIFF
--- a/.autotest
+++ b/.autotest
@@ -23,7 +23,7 @@ Autotest.add_hook :initialize do |at|
     at.files_matching(/test_.*rb$/)
   end
 
-  %w(TestEnvironment TestStackState).each do |klass|
+  %w(TestRPEnvironment TestStackState).each do |klass|
     at.extra_class_map[klass] = "test/test_ruby_parser_extras.rb"
   end
 

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -339,7 +339,7 @@ class RubyParser < Racc::Parser
     super
     self.lexer = RubyLexer.new
     self.lexer.parser = self
-    @env = Environment.new
+    @env = RPEnvironment.new
     @comments = []
 
     self.reset
@@ -891,7 +891,7 @@ class Keyword
   end
 end
 
-class Environment
+class RPEnvironment
   attr_reader :env, :dyn
 
   def [] k

--- a/test/test_ruby_parser_extras.rb
+++ b/test/test_ruby_parser_extras.rb
@@ -50,13 +50,13 @@ class TestStackState < MiniTest::Unit::TestCase
   end
 end
 
-class TestEnvironment < MiniTest::Unit::TestCase
+class TestRPEnvironment < MiniTest::Unit::TestCase
   def deny t
     assert ! t
   end
 
   def setup
-    @env = Environment.new
+    @env = RPEnvironment.new
     @env[:blah] = 42
     assert_equal 42, @env[:blah]
   end


### PR DESCRIPTION
I've re-named Environment class to RPEnvironment

  I was trying to bring our Rails 2.3.8 app into Ruby 1.9.2 (from Ruby 1.8.7).  We have a model named Environment in our app.  While running spec it would clash with the one defined by ruby_parser (resulting in a 'superclass mismatch' error).  Renaming Environment is maybe not the best solution (maybe putting stuff into a module would be better?), or maybe it is fine.  All tests pass.
