### PR TITLE
Fixed wrong line number after heredocs

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -199,6 +199,7 @@ class RubyLexer
       # TODO: think about storing off the char range instead
       line = src.string[src.pos, src.matched_size]
       src.string[src.pos, src.matched_size] = "\n"
+      src.extra_lines_added += 1
       src.pos += 1
     else
       line = nil

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -29,13 +29,18 @@ class RPStringScanner < StringScanner
 #       old_getch
 #     end
 #   end
-
+  def extra_lines_added
+    @extra_lines_added ||= 0
+  end
+  def extra_lines_added=(val)
+    @extra_lines_added = val
+  end
   def current_line # HAHA fuck you (HACK)
     string[0..pos][/\A.*__LINE__/m].split(/\n/).size
   end
 
   def lineno
-    string[0...pos].count("\n") + 1
+    string[0...pos].count("\n") + 1 - extra_lines_added
   end
 
   # TODO: once we get rid of these, we can make things like
@@ -48,6 +53,7 @@ class RPStringScanner < StringScanner
 
   def unread_many str # TODO: remove this entirely - we should not need it
     warn({:unread_many => caller[0]}.inspect) if ENV['TALLY']
+    self.extra_lines_added += str.count("\n")
     string[pos, 0] = str
   end
 

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -422,13 +422,13 @@ class TestRubyParser < RubyParserTestCase
     "case_nested_inner_no_expr"          => 2,
     "case_no_expr"                       => 2,
     "case_splat"                         => 2,
-    "dstr_heredoc_expand"                => 2,
-    "dstr_heredoc_windoze_sucks"         => 2,
-    "dstr_heredoc_yet_again"             => 2,
-    "str_heredoc"                        => 2,
-    "str_heredoc_call"                   => 2,
-    "str_heredoc_empty"                  => 2,
-    "str_heredoc_indent"                 => 2,
+    "dstr_heredoc_expand"                => 1,
+    "dstr_heredoc_windoze_sucks"         => 1,
+    "dstr_heredoc_yet_again"             => 1,
+    "str_heredoc"                        => 1,
+    "str_heredoc_call"                   => 1,
+    "str_heredoc_empty"                  => 1,
+    "str_heredoc_indent"                 => 1,
     "structure_unused_literal_wwtt"      => 3, # yes, 3... odd test
     "undef_block_1"                      => 2,
     "undef_block_2"                      => 2,
@@ -486,4 +486,15 @@ class TestRubyParser < RubyParserTestCase
     assert_equal 3, body.lasgn.line,  "lasgn should have line number"
     assert_equal 4, body.return.line, "return should have line number"
   end
+  def test_line_number_after_heredoc
+    rb = <<-CODE
+      string = <<-HEREDOC.size
+        very long string
+      HEREDOC
+      puts 'some code'
+    CODE
+    result = @processor.parse(rb)
+    assert_equal 4, result[2].line
+  end
+
 end


### PR DESCRIPTION
Hi!
I've made some changes to allow proper line numbers after heredocs.

There might be some compatibility issue, because, after the change the heredoc string line number is the line where the "<<HEREDOC" token was found and not the next line (See original values for STARTING_LINE in test_ruby_parser). I don't know if the original behaviour was intentional or not, but I couldn't figure out a way to properly handle both cases. If you can think a way to fix both cases I can take some time to make the patch

Thanks
