### PR TITLE
Support for not canonicalizing the handling of 'not' conditions in if, while and until expressions

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -682,7 +682,7 @@ class RubyParser < Racc::Parser
     else
       line = [block && block.line, expr.line].compact.min
       block, pre = block.last, false if block && block[0] == :begin
-      s(:until, expr.last, block, pre).line(line)
+      s(:until, expr, block, pre).line(line)
     end
   end
 


### PR DESCRIPTION
ruby_parser currently 'canonicalizes' conditions of if expressions, by removing the 'not' from them. For instance 

``` ruby
if foo != 1 
  'bar'
end
```

is turned into 

``` ruby
s(:if, s(:call, s(:call, nil, :foo, s(:arglist)), :==, 
  s(:arglist, s(:lit, 1))), nil, s(:str, "bar"))
```

instead of

``` ruby
s(:if, s(:not, s(:call, s(:call, nil, :foo, s(:arglist)), :==, 
  s(:arglist, s(:lit, 1)))), s(:str, "bar"), nil))
```

The same kind of things happens with while and until expressions, only here 'while' is replaced by 'until' (or vice versa) when a 'not' is removing. Ryan explained to me by email that this came about via parse_tree, because MRI does it this way. He said he may be open to a change that allows you to specify that you don't want any 'not' to be removed, as long as it was optional.

This pull request is my first proposal for that change. I use ruby_parser to instrument Ruby code and report on conditions to users, so it is very useful to me if the 'not' is retained, so I can report the original condition and don't have to scour the source file for the line (via the line number, which isn't always accurate) to see if there used to be a 'not' there. I imagine there are other people that want to use ruby_parser to instrument code, so others may be interested in this behavior.

There are different solutions possible and coding styles tend to differ, so I submit this as a first proposal. Please tell me what changes you would like to see. Some possible issues:
- The current solution uses an options Hash to #initialize; an alternative is an attr_accessor that needs to be set explicitly after instantiation. 
- There aren't many comments in the code. I chose Yard-style comments; you may prefer other-style comments or documentation elsewhere
- The name of the instance variable that indicates whether the expressions should be canonicalized may be longer than you like
- new_until could be changed to

``` ruby
if not @canonical_not_conditions
  line = [block && block.line, expr.line].compact.min
  block, pre = block.last, false if block && block[0] == :begin
  return s(:until, expr, block, pre).line(line)
end
expr = (expr.first == :not ? expr.last : s(:not, expr)).line(expr.line)
new_while block, expr, pre
```
