### PR TITLE
Removed append_to_block as suggested by the code

### DIFF
--- a/bin/ruby_parse
+++ b/bin/ruby_parse
@@ -1,6 +1,6 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby -s
 
-$q ||= true
+$q ||= false
 $g ||= false
 
 require 'rubygems'

--- a/lib/ruby_parser.y
+++ b/lib/ruby_parser.y
@@ -1679,7 +1679,7 @@ xstring_contents: none
                     }
                 | f_optarg tCOMMA f_opt
                     {
-                      result = self.append_to_block val[0], val[2]
+                      result = self.block_append val[0], val[2]
                     }
 
     restarg_mark: tSTAR2 | tSTAR

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -128,15 +128,6 @@ class RubyParser < Racc::Parser
   attr_accessor :lexer, :in_def, :in_single, :file
   attr_reader :env, :comments
 
-  def append_to_block head, tail # FIX: wtf is this?!? switch to block_append
-    return head if tail.nil?
-    return tail if head.nil?
-
-    head = s(:block, head) unless head.node_type == :block
-    head << tail
-    head
-  end
-
   def arg_add(node1, node2) # TODO: nuke
     return s(:arglist, node2) unless node1
 
@@ -225,9 +216,9 @@ class RubyParser < Racc::Parser
     return result
   end
 
-  def block_append(head, tail, strip_tail_block=false)
-    return head unless tail
-    return tail unless head
+  def block_append(head, tail)
+    return head if tail.nil?
+    return tail if head.nil?
 
     case head[0]
     when :lit, :str then
@@ -237,13 +228,9 @@ class RubyParser < Racc::Parser
     line = [head.line, tail.line].compact.min
 
     head = remove_begin(head)
-    head = s(:block, head) unless head[0] == :block
+    head = s(:block, head) unless head.node_type == :block
 
-    if strip_tail_block and Sexp === tail and tail[0] == :block then
-      head.push(*tail.values)
-    else
-      head << tail
-    end
+    head << tail
 
     head.line = line
     head


### PR DESCRIPTION
There was a single usage of 'append_to_block'. I replaced that by 'block_append', merged the code of the two (retaining what I thought was the most readable of the two variants) and removed the unused option 'strip_tail_block'.

To gain confidence no semantics were changed, I ran the parser against the Rubinius sources and compared the output to the ParseTree output. No new differences.
