### PR TITLE
fix some syntax

### DIFF
--- a/lib/ruby_parser.y
+++ b/lib/ruby_parser.y
@@ -1673,6 +1673,14 @@ xstring_contents: none
                     {
                       result = args val[0],    nil,    nil, val[1]
                     }
+                | f_arg tCOMMA f_optarg tCOMMA f_rest_arg tCOMMA f_arg opt_f_block_arg
+                    {
+                      result = args val[0], val[2], val[4], val[7], val[6]
+                    }
+                | f_arg tCOMMA f_rest_arg tCOMMA f_arg opt_f_block_arg
+                    {
+                      result = args val[0],    nil, val[2], val[5], val[4]
+                    }
                 |           f_optarg tCOMMA f_rest_arg opt_f_block_arg
                     {
                       result = args    nil, val[0], val[2], val[3]
@@ -1684,6 +1692,10 @@ xstring_contents: none
                 |                        f_rest_arg opt_f_block_arg
                     {
                       result = args    nil,    nil, val[0], val[1]
+                    }
+                |           f_rest_arg tCOMMA f_arg opt_f_block_arg
+                    {
+                      result = args    nil,    nil, val[0], val[3], val[2]
                     }
                 |                                       f_block_arg
                     {

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -150,7 +150,7 @@ class RubyParser < Racc::Parser
     node1
   end
 
-  def args arg, optarg, rest_arg, block_arg
+  def args arg, optarg, rest_arg, block_arg, post_arg = nil
     arg ||= s(:args)
 
     result = arg
@@ -164,6 +164,7 @@ class RubyParser < Racc::Parser
     result << rest_arg  if rest_arg
     result << :"&#{block_arg.last}" if block_arg
     result << optarg    if optarg # TODO? huh - processed above as well
+    post_arg[1..-1].each {|pa| result << pa } if post_arg
 
     result
   end


### PR DESCRIPTION
for 1.9 syntax
- lambda args without parentheses
- !a
- method calling/definition with postargs
