### PR TITLE
Add tLABEL

### DIFF
--- a/lib/ruby19_parser.y
+++ b/lib/ruby19_parser.y
@@ -7,7 +7,7 @@ token kCLASS kMODULE kDEF kUNDEF kBEGIN kRESCUE kENSURE kEND kIF kUNLESS
       kREDO kRETRY kIN kDO kDO_COND kDO_BLOCK kDO_LAMBDA kRETURN kYIELD kSUPER
       kSELF kNIL kTRUE kFALSE kAND kOR kNOT kIF_MOD kUNLESS_MOD kWHILE_MOD
       kUNTIL_MOD kRESCUE_MOD kALIAS kDEFINED klBEGIN klEND k__LINE__
-      k__FILE__ tIDENTIFIER tFID tGVAR tIVAR tCONSTANT tCVAR tNTH_REF
+      k__FILE__ tIDENTIFIER tFID tGVAR tIVAR tCONSTANT tLABEL tCVAR tNTH_REF
       tBACK_REF tSTRING_CONTENT tINTEGER tFLOAT tREGEXP_END tUPLUS
       tUMINUS tUMINUS_NUM tPOW tCMP tEQ tEQQ tNEQ tGEQ tLEQ tANDOP
       tOROP tMATCH tNMATCH tDOT tDOT2 tDOT3 tAREF tASET tLSHFT tRSHFT
@@ -1829,9 +1829,9 @@ xstring_contents: none
                     {
                       result = s(:array, val[0], val[2])
                     }
-                | variable tCOLON arg_value
+                | tLABEL arg_value
                     {
-                      result = s(:array, s(:lit, val[0].to_sym), val[2])
+                      result = s(:array, s(:lit, val[0][0].to_sym), val[1])
                     }
 
        operation: tIDENTIFIER | tCONSTANT | tFID

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -1265,6 +1265,20 @@ class RubyLexer
                    end
       end
 
+      if lex_state == :expr_beg || lex_state == :expr_arg || lex_state == :expr_cmdarg
+        colon = src.scan(/:/)
+
+        if colon && src.peek(1) != ":"
+          src.unscan
+          self.lex_state == :expr_beg
+          src.scan(/:/)
+          self.yacc_value = [token, src.lineno]
+          return :tLABEL
+        end
+
+        src.unscan if colon
+      end
+
       unless lex_state == :expr_dot then
         # See if it is a reserved word.
         keyword = RubyParser::Keyword.keyword token

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -127,6 +127,17 @@ class TestRubyLexer < MiniTest::Unit::TestCase
     util_lex_token "=>", :tASSOC, "=>"
   end
 
+  def test_yylex_label
+    util_lex_token "{a:", :tLBRACE, "{", :tLABEL, "a"
+  end
+
+  def test_yylex_label_in_params
+    util_lex_token "foo(a:",
+      :tIDENTIFIER, "foo",
+      :tLPAREN2, "(",
+      :tLABEL, "a"
+  end
+
   def test_yylex_back_ref
     util_lex_token("[$&, $`, $', $+]",
                    :tLBRACK,   "[",


### PR DESCRIPTION
This fixes issues with Ruby 1.9 hashes with no spaces after the colon:

```
foo(a:1)
```

Two important notes:
- This adds a 1.9 specific lexer modification. The lexer should be split for 1.8 vs. 1.9
- This fix _breaks_ behavior for calling a method with a symbol with no space and no parens:
  
  ```
  def foo(*args)
      puts args.inspect
  end
  
  foo:bar  # prints [:bar]
  ```

This needs to be fixed, but in my research the Ruby 1.9 hash with no space is much more common than the above case, so this is a net win.
