### PR TITLE
pass sexp_processor test_lambda_args_block__19 test

### DIFF
--- a/lib/ruby19_parser.y
+++ b/lib/ruby19_parser.y
@@ -1213,6 +1213,11 @@ rule
                       result = val[1]
                       self.lexer.command_start = true
                     }
+                | tPIPE tAMPER block_var tPIPE
+                    {
+                      result = s(:lasgn, :"&block")
+                      self.lexer.command_start = true
+                    }
 
         do_block: kDO_BLOCK
                     {


### PR DESCRIPTION
This change removes a test error for `test_lambda_args_block__19` test in sexp_processor.  I haven't worked with lexing/parsing in a while, so let me know if this solution is weird in some way and I will give it another try.
