### PR TITLE
remove method "d" from global namespace

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -5,10 +5,6 @@ require 'strscan'
 require 'ruby_lexer'
 require "timeout"
 
-def d o
-  $stderr.puts o.inspect
-end
-
 # WHY do I have to do this?!?
 class Regexp
   ONCE = 0 unless defined? ONCE # FIX: remove this - it makes no sense
@@ -75,6 +71,10 @@ class RPStringScanner < StringScanner
       d :scan => [s, caller.first] if s
       s
     end
+  end
+  
+  def d o
+    $stderr.puts o.inspect
   end
 end
 


### PR DESCRIPTION
ruby_parser_extras defines a method "d" (which is used exactly once, in the same file) in the public namespace (main). This conflicts with Wrong's "d" method which is part of a module; for some reason even when I "include Wrong::D" the ruby_parser one is called. It's basically bad form for a gem to clutter the global namespace in any case.

This patch puts it inside the (only) object where it's called.
