### PR TITLE
Add RubyParser.parser_for_current_version

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -1301,6 +1301,17 @@ class RubyParser
     @p18.reset
     @p19.reset
   end
+
+  def self.parser_for_current_version
+    case RUBY_VERSION
+    when /^1\.8/ then
+      Ruby18Parser.new
+    when /^(1\.9|2\.0)/ then
+      Ruby19Parser.new
+    else
+      raise "unrecognized RUBY_VERSION #{RUBY_VERSION}"
+    end
+  end
 end
 
 ############################################################


### PR DESCRIPTION
This returns a RubyParser instance that produces ASTs suitable for the current
version of the Ruby runtime in use (i.e., either 1.8 or 1.9).

See #89.
