### PR TITLE
Add test case for and fix behaviour when given 'a[] += b'.

### DIFF
--- a/lib/ruby18_parser.y
+++ b/lib/ruby18_parser.y
@@ -522,7 +522,7 @@ rule
                 | primary_value tLBRACK2 aref_args tRBRACK tOP_ASGN arg
                     {
                       result = s(:op_asgn1, val[0], val[2], val[4].to_sym, val[5])
-                      val[2][0] = :arglist
+                      val[2][0] = :arglist if val[2]
                     }
                 | primary_value tDOT tIDENTIFIER tOP_ASGN arg
                     {

--- a/lib/ruby19_parser.y
+++ b/lib/ruby19_parser.y
@@ -592,7 +592,7 @@ rule
                     }
                 | primary_value tLBRACK2 opt_call_args rbracket tOP_ASGN arg
                     {
-                      val[2][0] = :arglist
+                      val[2][0] = :arglist if val[2]
                       result = s(:op_asgn1, val[0], val[2], val[4].to_sym, val[5])
                     }
                 | primary_value tDOT tIDENTIFIER tOP_ASGN arg

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1745,6 +1745,13 @@ class TestRuby19Parser < RubyParserTestCase
     assert_parse rb, pt
   end
 
+  def test_index_0_opasgn
+    rb = "a[] += b"
+    pt = s(:op_asgn1, s(:call, nil, :a), nil, :+, s(:call, nil, :b))
+
+    assert_parse rb, pt
+  end
+
   def test_lambda_do_vs_brace
     pt = s(:call, nil, :f, s(:iter, s(:call, nil, :lambda), 0))
 


### PR DESCRIPTION
Currently the behaviour on hitting a code fragment like 'a[] += b' is to throw an error as val[2] has nil in it. The code is valid and ripper accepts it, leaving a nil in the field where the arguments would go, so I made this do the same.
