### PR TITLE
Skip leading spaces in %i %I literals

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -357,8 +357,10 @@ class RubyLexer
                                 self.lex_state  = :expr_fname
                                 [:tSYMBEG,       STR_SSYM]
                               when 'I' then
+                                src.scan(/\s*/)
                                 [:tSYMBOLS_BEG, STR_DQUOTE | STR_FUNC_QWORDS]
                               when 'i' then
+                                src.scan(/\s*/)
                                 [:tQSYMBOLS_BEG, STR_SQUOTE | STR_FUNC_QWORDS]
                               end
 

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2136,7 +2136,7 @@ class TestRubyLexer < Minitest::Test
   end
 
   def test_yylex_string_pct_i
-    util_lex_token("%i[s1 s2\ns3]",
+    util_lex_token("%i[ s1 s2\ns3]",
                    :tQSYMBOLS_BEG,   "%i[",
                    :tSTRING_CONTENT, "s1",
                    :tSPACE,              nil,
@@ -2148,7 +2148,7 @@ class TestRubyLexer < Minitest::Test
   end
 
   def test_yylex_string_pct_I
-    util_lex_token("%I[s1 s2\ns3]",
+    util_lex_token("%I[ s1 s2\ns3]",
                    :tSYMBOLS_BEG,    "%I[",
                    :tSTRING_CONTENT, "s1",
                    :tSPACE,              nil,
@@ -2167,7 +2167,7 @@ class TestRubyLexer < Minitest::Test
   end
 
   def test_yylex_string_pct_W
-    util_lex_token("%W[s1 s2\ns3]", # TODO: add interpolation to these
+    util_lex_token("%W[ s1 s2\ns3]", # TODO: add interpolation to these
                    :tWORDS_BEG,      "%W[",
                    :tSTRING_CONTENT, "s1",
                    :tSPACE,              nil,
@@ -2203,7 +2203,7 @@ class TestRubyLexer < Minitest::Test
   end
 
   def test_yylex_string_pct_w
-    util_bad_token("%w[s1 s2 ",
+    util_bad_token("%w[ s1 s2 ",
                    :tQWORDS_BEG,     "%w[",
                    :tSTRING_CONTENT, "s1",
                    :tSPACE,              nil,


### PR DESCRIPTION
This avoids ruby_parser failing on symbol literal arrays like %i[   foo bar] or %I[   foo bar] similar to how %w and %W are handled in Ruby. I also changed the tests to check if this works at least once for both symbol and word lists.
