### PR TITLE
Parse kwarg use as lvars, not calls

### DIFF
--- a/lib/ruby20_parser.y
+++ b/lib/ruby20_parser.y
@@ -2127,14 +2127,20 @@ keyword_variable: kNIL      { result = s(:nil)   }
                     {
                       # TODO: call_args
                       label, _ = val[0] # TODO: fix lineno?
-                      result = s(:array, s(:kwarg, label.to_sym, val[1]))
+                      identifier = label.to_sym
+                      self.env[identifier] = :lvar
+
+                      result = s(:array, s(:kwarg, identifier, val[1]))
                     }
 
       f_block_kw: tLABEL primary_value
                     {
                       # TODO: call_args
                       label, _ = val[0] # TODO: fix lineno?
-                      result = s(:array, s(:kwarg, label.to_sym, val[1]))
+                      identifier = label.to_sym
+                      self.env[identifier] = :lvar
+
+                      result = s(:array, s(:kwarg, identifier, val[1]))
                     }
 
    f_block_kwarg: f_block_kw

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2817,6 +2817,21 @@ class TestRuby20Parser < RubyParserTestCase
     assert_parse rb, pt
   end
 
+  def test_defn_kwarg_lvar
+    rb = "def fun(kw: :val); kw; end"
+    pt = s(:defn, :fun, s(:args, s(:kwarg, :kw, s(:lit, :val))), s(:lvar, :kw))
+
+    assert_parse rb, pt
+  end
+
+  def test_block_kwarg_lvar
+    rb = "bl { |kw: :val| kw }"
+    pt = s(:iter, s(:call, nil, :bl), s(:args, s(:kwarg, :kw, s(:lit, :val))),
+           s(:lvar, :kw))
+
+    assert_parse rb, pt
+  end
+
   def test_defn_powarg
     rb = "def f(**opts) end"
     pt = s(:defn, :f, s(:args, :"**opts"), s(:nil))


### PR DESCRIPTION
Currently, when a keyword argument is encountered in a method (or a block), it’s parsed as a function call: `s(:call, nil, :kwarg)`. I think it should be parsed as a variable: `s(:lvar, :kwarg)`.

This is an attempt to fix this, but I have zero Racc knowledge, so please review dilligently.
