### PR TITLE
remove reference to local path of pt_testcase

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -6,10 +6,8 @@
 require 'rubygems'
 require 'minitest/autorun'
 require 'ruby_parser'
-
-$: << File.expand_path('~/Work/p4/zss/src/sexp_processor/dev/lib')
-
-require 'pt_testcase'
+require 'sexp_processor'
+require File.join(Gem.loaded_specs['sexp_processor'].gem_dir, 'lib', 'pt_testcase')
 
 class Sexp
   alias oldeq2 ==


### PR DESCRIPTION
After a cloning the repo and installing dependencies, running `rake test` failed.

This commit loads `pt_testcase.rb` from the sexp_processor gem.
