### PR TITLE
Line numbers broken with inline comments

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -632,6 +632,19 @@ module TestRubyParserShared
     assert_same result.file, result.call.file
   end
 
+  def test_parse_line_block_inline_comment
+    rb = "a\nb # Comment\nc"
+    pt = s(:block,
+           s(:call, nil, :a),
+           s(:call, nil, :b),
+           s(:call, nil, :c))
+
+    assert_parse_line rb, pt, 1
+    assert_equal 1, result[1].line
+    assert_equal 2, result[2].line
+    assert_equal 3, result[3].line
+  end
+
   def test_parse_line_call_no_args
     rb = "f do |x, y|\n  x + y\nend"
 


### PR DESCRIPTION
8065014e1d6395d1fd067863a51c055e07e4f19d broke line numbers when inline comments are involved, specifically [at line 869](https://github.com/seattlerb/ruby_parser/commit/8065014e1d6395d1fd067863a51c055e07e4f19d#diff-f1ace03ba822d753c3e6129bcc3a8a71R869).

For example:

``` ruby
require 'ruby_parser'

sexp = RubyParser.new.parse <<RUBY
    a
    b # Comment
    c
RUBY

p sexp
puts sexp[1].line
puts sexp[2].line
puts sexp[3].line
```

output:

```
s(:block, s(:call, nil, :a), s(:call, nil, :b), s(:call, nil, :c))
1
3
3
```

I've attached a test case, and removing line 869 in `ruby_lexer.rb` fixes it.
