### PR TITLE
Test case for space between method and arg parens

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1211,6 +1211,14 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_call_space_before_paren_args
+    # This only parses in Ruby 1.8, with a warning
+    rb = "a (:b, :c, :d => :e)"
+    pt = s(:call, nil, :a, s(:lit, :b), s(:lit, :c), s(:hash, s(:lit, :d), s(:lit, :e)))
+
+    assert_parse rb, pt
+  end
+
   def test_call_bang_squiggle
     rb = "1 !~ 2"
     pt = s(:not, s(:call, s(:lit, 1), :=~, s(:lit, 2))) # TODO: check for 1.9+


### PR DESCRIPTION
Not sure if you still want/need this as [requested here](https://github.com/seattlerb/ruby_parser/blob/master/lib/ruby_parser_extras.rb#L1394), but here's a test case that raises that exception.
