### PR TITLE
Line number off for ivar argument followed by a line break

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -677,6 +677,22 @@ module TestRubyParserShared
     assert_equal 2, result[3].line,   "call should have line number"
   end
 
+  def test_parse_line_call_ivar_line_break_paren
+    rb = "a(@b\n)"
+    pt = s(:call, nil, :a, s(:ivar, :@b))
+
+    assert_parse rb, pt
+    assert_equal 1, result[3].line
+  end
+
+  def test_parse_line_call_ivar_arg_no_parens_line_break
+    rb = "a @b\n"
+    pt = s(:call, nil, :a, s(:ivar, :@b))
+
+    assert_parse rb, pt
+    assert_equal 1, result[3].line
+  end
+
   def test_parse_line_defn_no_parens
     pt = s(:defn, :f, s(:args), s(:nil))
 


### PR DESCRIPTION
Tests attached. It looks like the line break needs to be immediately after the instance variable (parens/no parens the same):

```
2.1.0 :002 > RubyParser.new.parse("a(@b\n)")[3].line
 => 2 
2.1.0 :003 > RubyParser.new.parse("a(@b \n)")[3].line
 => 1
```
