### PR TITLE
Add test for backslash and newline in dstr

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -717,6 +717,15 @@ module TestRubyParserShared
     assert_equal 4, body.return.line, "return should have line number"
   end
 
+  def test_parse_line_evstr_after_break
+    rb = "\"a\"\\\n\"\#{b}\""
+    pt = s(:dstr, "a",
+           s(:evstr,
+             s(:call, nil, :b).line(2)).line(2))
+
+    assert_parse rb, pt
+  end
+
   def test_parse_line_iter_call_parens
     rb = "f(a) do |x, y|\n  x + y\nend"
 


### PR DESCRIPTION
Hard to see in test, but with this code:

``` ruby
"a"\
"#{b}"
```

the line returned for `"#{b}"` is 1 when it should be 2.
