### PR TITLE
Add test for line numbers after trailing spaces

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -806,6 +806,15 @@ module TestRubyParserShared
     assert_equal 3, result.if.return.lit.line
   end
 
+  def test_parse_line_trailing_newlines
+    rb = "a \nb"
+    pt = s(:block,
+           s(:call, nil, :a).line(1),
+           s(:call, nil, :b).line(2))
+
+    assert_parse rb, pt
+  end
+
   def test_bug_and
     rb = "true and []"
     pt = s(:and, s(:true), s(:array))


### PR DESCRIPTION
Now I realize my test name is not quite right.

Anyway, trailing space followed by a newline messes up line numbers following it.
