### PR TITLE
Line for interpolation inside heredoc is off

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -720,6 +720,16 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_parse_line_heredoc_evstr
+    rb = "<<-A\na\n\#{b}\nA"
+    pt = s(:dstr, "a\n",
+           s(:evstr,
+             s(:call, nil, :b).line(3)),
+             s(:str, "\n")).line(1)
+
+    assert_parse rb, pt
+  end
+
   def test_parse_line_iter_call_parens
     rb = "f(a) do |x, y|\n  x + y\nend"
 


### PR DESCRIPTION
For this code:

``` ruby
<<-DOC
a
#{b}
DOC
```

ruby_parser 3.3.0 reports `b` as being on line 1. Current master reports `b` on line 2. Seems like 3 would be the most correct value.
