### PR TITLE
Failing test for multiple kwargs in blocks

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2954,6 +2954,15 @@ class TestRuby20Parser < RubyParserTestCase
     assert_parse rb, pt
   end
 
+  def test_block_kwarg_lvar_multiple
+    rb = "bl { |kw: :val, kw2: :val2 | kw }"
+    pt = s(:iter, s(:call, nil, :bl), s(:args, s(:kwarg, :kw, s(:lit, :val)),
+                                               s(:kwarg, :ks2, s(:lit, :val2))),
+           s(:lvar, :kw))
+
+    assert_parse rb, pt
+  end
+
   def test_defn_powarg
     rb = "def f(**opts) end"
     pt = s(:defn, :f, s(:args, :"**opts"), s(:nil))


### PR DESCRIPTION
Hey there!

This code:

``` ruby
Proc.new{ |kw: :val, kw2: :val2 | [kw,kw2] }[{}]
```

raises a `not yet` error when run through the Ruby20Parser. I added a failing test case. I'm sorry if this is already on your radar (as indicated by this error being raised?) just didn't see any obvious other way to handle it and a failing test case always seems useful.
