### PR TITLE
Add test for line number after multiline string

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -732,6 +732,15 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_parse_line_multiline_str
+    rb = "\"a\nb\"\n1"
+    pt = s(:block,
+           s(:str, "a\nb").line(1),
+           s(:lit, 1).line(3))
+
+    assert_parse rb, pt
+  end
+
   def test_parse_line_iter_call_parens
     rb = "f(a) do |x, y|\n  x + y\nend"
 


### PR DESCRIPTION
Line numbers are off after strings containing newlines. I assume this is similar to #150.
