### PR TITLE
New line escape character interpreted as a new lines

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -827,6 +827,17 @@ module TestRubyParserShared
     assert_equal 3, result.if.return.lit.line
   end
 
+  def test_parse_line_str_with_newline_escape
+    rb = 'a("\n", true)'
+    pt = s(:call,
+           nil,
+           :a,
+           s(:str, "\n").line(1),
+           s(:true).line(1))
+
+    assert_parse rb, pt
+  end
+
   def test_parse_line_trailing_newlines
     rb = "a \nb"
     pt = s(:block,


### PR DESCRIPTION
It seems that literal new lines inside a string and the new line escape character are being treated the same.

```
2.1.1 :001 > require 'ruby_parser'
 => true 
2.1.1 :002 > input = 'a("\n", true)'
 => "a(\"\\n\", true)" 
2.1.1 :003 > puts input
a("\n", true)
 => nil 
2.1.1 :004 > sexp = RubyParser.new.parse input
"\n"
1
 => s(:call, nil, :a, s(:str, "\n"), s(:true)) 
2.1.1 :005 > puts sexp[3]
str

 => nil 
2.1.1 :006 > sexp[4]
 => s(:true) 
2.1.1 :007 > sexp[4].line
 => 2 
```
