### PR TITLE
Add line numbers from block comments =begin/=end

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -322,6 +322,7 @@ class RubyLexer
     end
 
     @comments << matched
+    self.lineno += matched.count("\n")
 
     nil # TODO
   end

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -316,6 +316,15 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_eq_begin_line_numbers
+    rb = "1\n=begin\ncomment\ncomment\n=end\n2"
+    pt = s(:block,
+           s(:lit, 1).line(1),
+           s(:lit, 2).line(6))
+
+    assert_parse rb, pt
+  end
+
   def test_bug_call_arglist_parens
     rb = 'g ( 1), 2'
     pt = s(:call, nil, :g, s(:lit, 1), s(:lit, 2))


### PR DESCRIPTION
Currently ruby_parser is not accounting for lines inside of block comments.