### PR TITLE
Genearating the "stub of a test" for #183

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3288,4 +3288,23 @@ class TestRuby21Parser < RubyParserTestCase
 
     assert_parse rb, pt
   end
+
+  def test_multiline_hash_declaration
+    rb = <<-'CODE'.gsub(/^      /, '')
+     enum(
+        state:
+        {
+          CREATED_STATE => CREATED_STATE,
+          CLAIMED_STATE => CLAIMED_STATE
+        },
+        identifier_type:
+        {
+          ORCID_IDENTIFIER_TYPE => ORCID_IDENTIFIER_TYPE,
+          NETID_IDENTIFIER_TYPE => NETID_IDENTIFIER_TYPE
+        }
+      )
+    CODE
+
+    processor.class.new.parse(rb)
+  end
 end


### PR DESCRIPTION
I'm not well versed in sexp language, but the test that I'm adding
produces the error under ruby 2.1.5. It is hopefully a further step in
resolving the issue.

Related to #183 