### PR TITLE
Parse stabby lambda args same as Kernel#lambda

### DIFF
--- a/lib/ruby19_parser.y
+++ b/lib/ruby19_parser.y
@@ -1382,8 +1382,6 @@ rule
                       lpar, args, body = val
                       lexer.lpar_beg = lpar
 
-                      args = 0 if args == s(:args)
-
                       call = new_call nil, :lambda
                       result = new_iter call, args, body
                     }

--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1482,8 +1482,6 @@ opt_block_args_tail: tCOMMA block_args_tail
                       lpar, args, body = val
                       lexer.lpar_beg = lpar
 
-                      args = 0 if args == s(:args)
-
                       call = new_call nil, :lambda
                       result = new_iter call, args, body
                       self.env.unextend

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2019,9 +2019,9 @@ module TestRubyParserShared19to22
     assert_parse rb, pt
   end
 
-  def test_do_lambda
+  def test_do_lambda_no_args
     rb = "->() do end"
-    pt = s(:iter, s(:call, nil, :lambda), 0)
+    pt = s(:iter, s(:call, nil, :lambda), s(:args))
 
     assert_parse rb, pt
   end
@@ -3036,7 +3036,7 @@ class TestRuby19Parser < RubyParserTestCase
   end
 
   def test_lambda_do_vs_brace
-    pt = s(:call, nil, :f, s(:iter, s(:call, nil, :lambda), 0))
+    pt = s(:call, nil, :f, s(:iter, s(:call, nil, :lambda), s(:args)))
 
     rb = "f ->() {}"
     assert_parse rb, pt


### PR DESCRIPTION
[Fixes #186]

Prior to this change, stabby lambda parsed empty argument list
as an integer zero.

    s(:iter, s(:call, nil, :lambda), 0)

After this change, stabby lambda parses empty argument list
as `s(:args)`

    s(:iter, s(:call, nil, :lambda), s(:args))

This fixes an inconsistency between stabby lambda and
Kernel#lambda, and will simplify sexp processors like ruby2ruby.

Will require a change to SexpProcessor's tests.