### PR TITLE
change debug environment variable name

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -1202,7 +1202,7 @@ end
 
 require "ruby_lexer.rex"
 
-if ENV["DEBUG"] then
+if ENV["RP_LINENO_DEBUG"] then
   class RubyLexer
     alias :old_lineno= :lineno=
 


### PR DESCRIPTION
DEBUG is a fairly common name.  We enabled this to debug something else,
and outputting the debugging information took so long that it caused the
parser to timeout (even though it would parse just fine if silent).