### PR TITLE
Add test for line breaks inside %w()

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1397,6 +1397,17 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_qwords_line_breaks
+    rb = "%w(\na\nb\n)\n1"
+    pt = s(:block,
+           s(:array,
+             s(:str, "a").line(2),
+             s(:str, "b").line(3)).line(1),
+           s(:lit, 1).line(5))
+
+    assert_parse rb, pt
+  end
+
   def test_qWords_space
     rb = "%W( )"
     pt = s(:array)


### PR DESCRIPTION
From https://github.com/presidentbeef/brakeman/pull/746

If a `%w()` contains newlines, they are not counted.

```
2.2.1 :001 > require 'ruby_parser'
 => true 
2.2.1 :002 > e = RubyParser.new.parse <<RUBY
2.2.1 :003"> %w(
2.2.1 :004"> a
2.2.1 :005"> b
2.2.1 :006"> )
2.2.1 :007"> c
2.2.1 :008"> RUBY
 => s(:block, s(:array, s(:str, "a"), s(:str, "b")), s(:call, nil, :c)) 
2.2.1 :009 > e[1].line
 => 1 
2.2.1 :010 > e[1][1].line
 => 1 
2.2.1 :011 > e[1][2].line
 => 1 
2.2.1 :012 > e[2].line
 => 2
```

It seems newlines may be consumed [here](https://github.com/seattlerb/ruby_parser/blob/master/lib/ruby_lexer.rb#L1133,L1136) and [here](https://github.com/seattlerb/ruby_parser/blob/master/lib/ruby_lexer.rb#L1179). I futzed around with it for a while but couldn't get it to come out right.