### PR TITLE
Parse kwargs in defs with no parens

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1203,7 +1203,7 @@ rule
                     {
                       self.in_single += 1
                       self.env.extend
-                      lexer.lex_state = :expr_end # force for args
+                      lexer.lex_state = :expr_endfn # force for args
                       result = lexer.lineno
                     }
                     f_arglist bodystmt kEND

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2171,10 +2171,8 @@ end
 
 module TestRubyParserShared20to22
   def test_defs_kwarg
-    skip "not yet"
-
     rb = "def self.a b: 1\nend"
-    pt = s(:defs, s(:self), :a, s(:args, s(:kwarg, :b, s(:lit, 1))), s(:nil))
+    pt = s(:defs, s(:self), :a, s(:args, s(:kwarg, :b, s(:lit, 1))))
 
     assert_parse rb, pt
   end


### PR DESCRIPTION
It's a holiday miracle: me suggesting a change to the actual parser :snowman: 

This is a fix for #193, which apparently already had a test.

While looking at this, I realized there is a discrepancy between `def` and `defs` with empty bodies:

```
2.2.1 :001 > require 'ruby_parser'
 => true 
2.2.1 :002 > RubyParser.new.parse "def x; end"
 => s(:defn, :x, s(:args), s(:nil)) 
2.2.1 :003 > RubyParser.new.parse "def self.y; end"
 => s(:defs, s(:self), :y, s(:args)) 
```

Since that seems unrelated to the kwargs issue, I figured it's out of scope and changed the test. Probably should have a separate test for it.