### PR TITLE
Fix parsing of { 'a': :b }

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -680,9 +680,9 @@ class RubyLexer
   end
 
   def process_label text
-    result = process_symbol text
-    result[0] = :tLABEL
-    result
+    symbol = match[1].gsub(ESC) { unescape $1 }
+
+    result(:expr_labelarg, :tLABEL, symbol)
   end
 
   def process_token text

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -680,9 +680,9 @@ class RubyLexer
   end
 
   def process_label text
-    symbol = match[1].gsub(ESC) { unescape $1 }
+    symbol = text[1..-3].gsub(ESC) { unescape $1 }
 
-    result(:expr_labelarg, :tLABEL, symbol)
+    result(:expr_labelarg, :tLABEL, [symbol, self.lineno])
   end
 
   def process_token text

--- a/lib/ruby_lexer.rex
+++ b/lib/ruby_lexer.rex
@@ -61,7 +61,7 @@ rule
 | bol?          /\=begin(?=\s)/         process_begin
 |               /\=(?=begin\b)/         { result arg_state, TOKENS[text], text }
 
-ruby22_label?   /\"(#{SIMPLE_STRING})\":/o process_label
+ruby22_label?   /\"#{SIMPLE_STRING}\":/o process_label
                 /\"(#{SIMPLE_STRING})\"/o { result :expr_end, :tSTRING, text[1..-2].gsub(ESC) { unescape $1 } }
                 /\"/                    { string STR_DQUOTE; result nil, :tSTRING_BEG, text }
 

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2653,11 +2653,24 @@ class TestRubyLexer < Minitest::Test
     assert_lex("{'a':1}",
                s(:hash, s(:lit, :a), s(:lit, 1)),
 
-               :tLBRACE, "{", :expr_beg,    0, 1,
-               :tLABEL,  "a", :expr_end,    0, 1,
-               :tINTEGER, 1,  :expr_end,    0, 1,
-               :tRCURLY, "}", :expr_endarg, 0, 0)
+               :tLBRACE, "{", :expr_beg,      0, 1,
+               :tLABEL,  "a", :expr_labelarg, 0, 1,
+               :tINTEGER, 1,  :expr_end,      0, 1,
+               :tRCURLY, "}", :expr_endarg,   0, 0)
   end
+
+  def test_yylex_hash_colon_quoted_symbol_22
+    setup_lexer_class Ruby22Parser
+
+    assert_lex("{'a': :b}",
+               s(:hash, s(:lit, :a), s(:lit, :b)),
+
+               :tLBRACE, "{", :expr_beg,      0, 1,
+               :tLABEL,  "a", :expr_labelarg, 0, 1,
+               :tSYMBOL, "b",  :expr_end,     0, 1,
+               :tRCURLY, "}", :expr_endarg,   0, 0)
+  end
+
 
   def test_ruby21_new_numbers
     skip "Don't have imaginary and rational literal lexing yet"

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2662,15 +2662,26 @@ class TestRubyLexer < Minitest::Test
   def test_yylex_hash_colon_quoted_symbol_22
     setup_lexer_class Ruby22Parser
 
-    assert_lex("{'a': :b}",
-               s(:hash, s(:lit, :a), s(:lit, :b)),
+    assert_lex("{'abc': :b}",
+               s(:hash, s(:lit, :abc), s(:lit, :b)),
 
                :tLBRACE, "{", :expr_beg,      0, 1,
-               :tLABEL,  "a", :expr_labelarg, 0, 1,
+               :tLABEL,  "abc", :expr_labelarg, 0, 1,
                :tSYMBOL, "b",  :expr_end,     0, 1,
                :tRCURLY, "}", :expr_endarg,   0, 0)
   end
 
+  def test_yylex_hash_colon_double_quoted_symbol_22
+    setup_lexer_class Ruby22Parser
+
+    assert_lex('{"abc": :b}',
+               s(:hash, s(:lit, :abc), s(:lit, :b)),
+
+               :tLBRACE, "{", :expr_beg,      0, 1,
+               :tLABEL,  "abc", :expr_labelarg, 0, 1,
+               :tSYMBOL, "b",  :expr_end,     0, 1,
+               :tRCURLY, "}", :expr_endarg,   0, 0)
+  end
 
   def test_ruby21_new_numbers
     skip "Don't have imaginary and rational literal lexing yet"

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3384,6 +3384,20 @@ class TestRuby22Parser < RubyParserTestCase
     rb = "a ? \"\": b"
     assert_parse rb, pt
   end
+
+  def test_quoted_symbol_keys
+    rb = "{ 'a': :b }"
+    pt = s(:hash, s(:lit, :a), s(:lit, :b))
+
+    assert_parse rb, pt
+  end
+
+  def test_quoted_symbol_hash_arg
+    rb = "puts 'a': {}"
+    pt = s(:call, nil, :puts, s(:hash, s(:lit, :a), s(:hash)))
+
+    assert_parse rb, pt
+  end
 end
 
 [18, 19, 20, 21, 22].each do |v|


### PR DESCRIPTION
Addresses issues in #175. Essentially the change is to set the lexer state to `:expr_labelarg` after a quoted symbol, because parsing of symbols and blocks check for `:expr_end`. I think this should work fine, because `'a':` is not a complete expression in itself.

Also fixes

```ruby
puts 'a': {}
```

I'm not sure if this should be limited to certain Ruby versions or not.