### PR TITLE
More safe navigation

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1598,6 +1598,13 @@ opt_block_args_tail: tCOMMA block_args_tail
                     {
                       result = new_call val[0], :call, val[2]
                     }
+#if defined(RUBY23)
+                | primary_value tLONELY paren_args
+                    {
+                      result = new_call val[0], :call, val[2]
+                      result[0] = :safe_call
+                    }
+#endif
                 | primary_value tCOLON2 paren_args
                     {
                       result = new_call val[0], :call, val[2]

--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -317,6 +317,13 @@ rule
                     {
                       result = new_call val[0], val[2].to_sym, val[3]
                     }
+#if defined(RUBY23)
+                | primary_value tLONELY operation2 command_args =tLOWEST
+                    {
+                      result = new_call val[0], val[2].to_sym, val[3]
+                      result[0] = :safe_call
+                    }
+#endif
                 | primary_value tDOT operation2 command_args cmd_brace_block
                     {
                       recv, _, msg, args, block = val

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3435,6 +3435,13 @@ class TestRuby23Parser < RubyParserTestCase
 
     assert_parse rb, pt
   end
+
+  def test_safe_call_operator
+    rb = "a&.> 1"
+    pt = s(:safe_call, s(:call, nil, :a), :>, s(:lit, 1))
+
+    assert_parse rb, pt
+  end
 end
 
 

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3428,6 +3428,13 @@ class TestRuby23Parser < RubyParserTestCase
 
     assert_parse rb, pt
   end
+
+  def test_safe_call_dot_parens
+    rb = "a&.()"
+    pt = s(:safe_call, s(:call, nil, :a), :call)
+
+    assert_parse rb, pt
+  end
 end
 
 


### PR DESCRIPTION
`a&.()` and `a&.> 1`

Sorry the tests don't merge cleanly with #210 