### PR TITLE
Add test for newline after safe_call

### DIFF
--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3422,6 +3422,13 @@ class TestRuby23Parser < RubyParserTestCase
     assert_parse rb, pt
   end
 
+  def test_safe_call_newline
+    rb = "a&.b\n"
+    pt = s(:safe_call, s(:call, nil, :a), :b)
+
+    assert_parse rb, pt
+  end
+
   def test_safe_calls
     rb = "a&.b&.c(1)"
     pt = s(:safe_call, s(:safe_call, s(:call, nil, :a), :b), :c, s(:lit, 1))


### PR DESCRIPTION
```ruby
require 'ruby_parser'

Ruby23Parser.new.parse "a&.b = 1\n" # Fine
Ruby23Parser.new.parse "a&.b()\n" # Fine
Ruby23Parser.new.parse "a&.b\n" # Not fine
```

Lexing seems fine, both `a.b` and `a&.b` end up with `tNL` token. Something after that must be different...haven't figured it out.