### PR TITLE
Dirty hack to "fix" multiline array issues

### DIFF
--- a/lib/ruby18_parser.y
+++ b/lib/ruby18_parser.y
@@ -1495,12 +1495,11 @@ rule
 
        word_list: none
                     {
-                      result = s(:array)
+                      result = new_word_list
                     }
                 | word_list word tSPACE
                     {
-                      word = val[1][0] == :evstr ? s(:dstr, "", val[1]) : val[1]
-                      result = val[0] << word
+                      result = val[0] << new_word_list_entry(val)
                     }
 
             word: string_content
@@ -1520,11 +1519,11 @@ rule
 
       qword_list: none
                     {
-                      result = s(:array)
+                      result = new_qword_list
                     }
                 | qword_list tSTRING_CONTENT tSPACE
                     {
-                      result = val[0] << s(:str, val[1])
+                      result = val[0] << new_qword_list_entry(val)
                     }
 
  string_contents: none
@@ -1563,10 +1562,10 @@ xstring_contents: none
                     }
                 | tSTRING_DBEG
                     {
-                      result = [lexer.lex_strterm, 
-                                lexer.brace_nest, 
+                      result = [lexer.lex_strterm,
+                                lexer.brace_nest,
                                 lexer.string_nest, # TODO: remove
-                                lexer.cond.store, 
+                                lexer.cond.store,
                                 lexer.cmdarg.store]
 
                       lexer.lex_strterm = nil

--- a/lib/ruby19_parser.y
+++ b/lib/ruby19_parser.y
@@ -1619,12 +1619,11 @@ rule
 
        word_list: none
                     {
-                      result = s(:array)
+                      result = new_word_list
                     }
                 | word_list word tSPACE
                     {
-                      word = val[1][0] == :evstr ? s(:dstr, "", val[1]) : val[1]
-                      result = val[0] << word
+                      result = val[0] << new_word_list_entry(val)
                     }
 
             word: string_content
@@ -1644,11 +1643,11 @@ rule
 
       qword_list: none
                     {
-                      result = s(:array)
+                      result = new_qword_list
                     }
                 | qword_list tSTRING_CONTENT tSPACE
                     {
-                      result = val[0] << s(:str, val[1])
+                      result = val[0] << new_qword_list_entry(val)
                     }
 
  string_contents: none
@@ -1696,10 +1695,10 @@ regexp_contents: none
                     }
                 | tSTRING_DBEG
                     {
-                      result = [lexer.lex_strterm, 
-                                lexer.brace_nest, 
+                      result = [lexer.lex_strterm,
+                                lexer.brace_nest,
                                 lexer.string_nest, # TODO: remove
-                                lexer.cond.store, 
+                                lexer.cond.store,
                                 lexer.cmdarg.store]
 
                       lexer.lex_strterm = nil
@@ -1793,9 +1792,9 @@ keyword_variable: kNIL      { result = s(:nil)   }
                 | kFALSE    { result = s(:false) }
                 | k__FILE__ { result = s(:str, self.file) }
                 | k__LINE__ { result = s(:lit, lexer.lineno) }
-                | k__ENCODING__ 
-                    { 
-                      result = 
+                | k__ENCODING__
+                    {
+                      result =
                         if defined? Encoding then
                           s(:colon2, s(:const, :Encoding), :UTF_8)
                         else

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -1132,9 +1132,11 @@ class RubyLexer
                                 [:tSTRING_BEG,   STR_SQUOTE]
                               when 'W' then
                                 scan(/\s*/)
+                                self.extra_lineno += matched.count("\n")
                                 [:tWORDS_BEG,    STR_DQUOTE | STR_FUNC_QWORDS]
                               when 'w' then
                                 scan(/\s*/)
+                                self.extra_lineno += matched.count("\n")
                                 [:tQWORDS_BEG,   STR_SQUOTE | STR_FUNC_QWORDS]
                               when 'x' then
                                 [:tXSTRING_BEG,  STR_XQUOTE]
@@ -1145,9 +1147,11 @@ class RubyLexer
                                 [:tSYMBEG,       STR_SSYM]
                               when 'I' then
                                 scan(/\s*/)
+                                self.extra_lineno += matched.count("\n")
                                 [:tSYMBOLS_BEG, STR_DQUOTE | STR_FUNC_QWORDS]
                               when 'i' then
                                 scan(/\s*/)
+                                self.extra_lineno += matched.count("\n")
                                 [:tQSYMBOLS_BEG, STR_SQUOTE | STR_FUNC_QWORDS]
                               end
 
@@ -1177,7 +1181,10 @@ class RubyLexer
       return :tSTRING_END, nil
     end
 
-    space = true if qwords and scan(/\s+/)
+    if qwords and scan(/\s+/)
+      space = true
+      self.extra_lineno += matched.count("\n")
+    end
 
     if self.string_nest == 0 && scan(/#{term_re}/) then
       if qwords then

--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1758,12 +1758,11 @@ opt_block_args_tail: tCOMMA block_args_tail
 
        word_list: none
                     {
-                      result = s(:array)
+                      result = new_word_list
                     }
                 | word_list word tSPACE
                     {
-                      word = val[1][0] == :evstr ? s(:dstr, "", val[1]) : val[1]
-                      result = val[0].dup << word
+                      result = val[0].dup << new_word_list_entry(val)
                     }
 
             word: string_content
@@ -1783,23 +1782,11 @@ opt_block_args_tail: tCOMMA block_args_tail
 
      symbol_list: none
                     {
-                      result = s(:array)
+                      result = new_symbol_list
                     }
                 | symbol_list word tSPACE
                     {
-                      list, sym, _ = val
-
-                      case sym[0]
-                      when :dstr then
-                        sym[0] = :dsym
-                      when :str then
-                        sym = s(:lit, sym.last.to_sym)
-                      else
-                        debug20 24
-                        sym = s(:dsym, "", result)
-                      end
-
-                      result = list.dup << sym
+                      result = val[0].dup << new_symbol_list_entry(val)
                     }
 
           qwords: tQWORDS_BEG tSPACE tSTRING_END
@@ -1822,20 +1809,20 @@ opt_block_args_tail: tCOMMA block_args_tail
 
       qword_list: none
                     {
-                      result = s(:array)
+                      result = new_qword_list
                     }
                 | qword_list tSTRING_CONTENT tSPACE
                     {
-                      result = val[0].dup << s(:str, val[1])
+                      result = val[0].dup << new_qword_list_entry(val)
                     }
 
        qsym_list: none
                     {
-                      result = s(:array)
+                      result = new_qsym_list
                     }
                 | qsym_list tSTRING_CONTENT tSPACE
                     {
-                      result = val[0].dup << s(:lit, val[1].to_sym)
+                      result = val[0].dup << new_qsym_list_entry(val)
                     }
 
  string_contents: none
@@ -1883,10 +1870,10 @@ regexp_contents: none
                     }
                 | tSTRING_DBEG
                     {
-                      result = [lexer.lex_strterm, 
-                                lexer.brace_nest, 
+                      result = [lexer.lex_strterm,
+                                lexer.brace_nest,
                                 lexer.string_nest, # TODO: remove
-                                lexer.cond.store, 
+                                lexer.cond.store,
                                 lexer.cmdarg.store,
                                 lexer.lex_state,
                                ]

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -1133,7 +1133,7 @@ module RubyParserStuff
   # Timeout::Error if it runs for more than +time+ seconds.
 
   def process(str, file = "(string)", time = 10)
-    # Timeout.timeout time do
+    Timeout.timeout time do
       raise "bad val: #{str.inspect}" unless String === str
 
       str = handle_encoding str
@@ -1146,7 +1146,7 @@ module RubyParserStuff
       self.lexer.ss = RPStringScanner.new str
 
       do_parse
-    # end
+    end
   end
   alias :parse :process
 

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -884,7 +884,6 @@ module RubyParserStuff
     str = val[1]
     str.force_encoding("ASCII-8BIT") unless str.valid_encoding? unless RUBY_VERSION < "1.9"
     result = s(:str, str)
-    require 'pry-byebug'; binding.pry if val.to_s =~ /fooblah/
     self.lexer.lineno += self.lexer.extra_lineno
     self.lexer.extra_lineno = 0
     result
@@ -894,17 +893,13 @@ module RubyParserStuff
     result = s(:array)
     self.lexer.lineno += self.lexer.extra_lineno
     self.lexer.extra_lineno = 0
-    # require 'pry-byebug'; binding.pry
     result
   end
 
   def new_word_list
     result = s(:array)
-    # result.line = 9
-    # require 'pry-byebug'; binding.pry if result.line == 2
     self.lexer.lineno += self.lexer.extra_lineno
     self.lexer.extra_lineno = 0
-    # require 'pry-byebug'; binding.pry
     result
   end
 
@@ -912,7 +907,6 @@ module RubyParserStuff
     result = val[1][0] == :evstr ? s(:dstr, "", val[1]) : val[1]
     self.lexer.lineno += self.lexer.extra_lineno
     self.lexer.extra_lineno = 0
-    # require 'pry-byebug'; binding.pry if val.to_s =~ /fooblah/
     result
   end
 
@@ -927,7 +921,6 @@ module RubyParserStuff
     result = s(:lit, val[1].to_sym)
     self.lexer.lineno += self.lexer.extra_lineno
     self.lexer.extra_lineno = 0
-    # require 'pry-byebug'; binding.pry if val.to_s =~ /fooblah/
     result
   end
 
@@ -1155,12 +1148,6 @@ module RubyParserStuff
       do_parse
     # end
   end
-
-  def call_string(val)
-    # require 'pry-byebug'; binding.pry if val.to_s =~ /foobar/
-    return
-  end
-
   alias :parse :process
 
   def remove_begin node

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -880,6 +880,84 @@ module RubyParserStuff
     result
   end
 
+  def new_qword_list_entry val
+    str = val[1]
+    str.force_encoding("ASCII-8BIT") unless str.valid_encoding? unless RUBY_VERSION < "1.9"
+    result = s(:str, str)
+    require 'pry-byebug'; binding.pry if val.to_s =~ /fooblah/
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    result
+  end
+
+  def new_qword_list
+    result = s(:array)
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    # require 'pry-byebug'; binding.pry
+    result
+  end
+
+  def new_word_list
+    result = s(:array)
+    # result.line = 9
+    # require 'pry-byebug'; binding.pry if result.line == 2
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    # require 'pry-byebug'; binding.pry
+    result
+  end
+
+  def new_word_list_entry val
+    result = val[1][0] == :evstr ? s(:dstr, "", val[1]) : val[1]
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    # require 'pry-byebug'; binding.pry if val.to_s =~ /fooblah/
+    result
+  end
+
+  def new_qsym_list
+    result = s(:array)
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    result
+  end
+
+  def new_qsym_list_entry val
+    result = s(:lit, val[1].to_sym)
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    # require 'pry-byebug'; binding.pry if val.to_s =~ /fooblah/
+    result
+  end
+
+  def new_symbol_list
+    result = s(:array)
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    result
+  end
+
+  def new_symbol_list_entry val
+    list, sym, _ = val
+    result = val[1]
+
+    result ||= s(:str, "")
+
+    case sym[0]
+    when :dstr then
+      sym[0] = :dsym
+    when :str then
+      sym = s(:lit, sym.last.to_sym)
+    else
+      debug20 24
+      sym = s(:dsym, "", sym || s(:str, ""))
+    end
+    self.lexer.lineno += self.lexer.extra_lineno
+    self.lexer.extra_lineno = 0
+    sym
+  end
+
   def new_super args
     if args && args.node_type == :block_pass then
       s(:super, args)
@@ -1062,7 +1140,7 @@ module RubyParserStuff
   # Timeout::Error if it runs for more than +time+ seconds.
 
   def process(str, file = "(string)", time = 10)
-    Timeout.timeout time do
+    # Timeout.timeout time do
       raise "bad val: #{str.inspect}" unless String === str
 
       str = handle_encoding str
@@ -1075,7 +1153,12 @@ module RubyParserStuff
       self.lexer.ss = RPStringScanner.new str
 
       do_parse
-    end
+    # end
+  end
+
+  def call_string(val)
+    # require 'pry-byebug'; binding.pry if val.to_s =~ /foobar/
+    return
   end
 
   alias :parse :process

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2562,7 +2562,7 @@ class TestRuby18Parser < RubyParserTestCase
     assert_parse rb, pt
   end
 end
-#
+
 class TestRuby19Parser < RubyParserTestCase
   include TestRubyParserShared
   include TestRubyParserShared19to22
@@ -3176,7 +3176,7 @@ class TestRuby19Parser < RubyParserTestCase
     assert_parse rb, pt
   end
 end
-#
+
 class TestRuby20Parser < RubyParserTestCase
   include TestRubyParserShared
   include TestRubyParserShared20to22


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ 

We use Brakeman a fair bit (which uses `ruby_parser`) to make line level comments on potential security issues. As a result, line numbers are relatively important to us, or the comments end up getting left on completely unrelated parts of the code. The most frequent issue we have seen with this is multiline arrays. It seems that ruby_parser doesn't handle multiline array literals correctly as was noted in https://github.com/seattlerb/ruby_parser/pull/199. After looking through the code, it seems like the general reason why this happens is that there are several locations in the code that do something like `scan(/\s+/)`. This ends up moving the parser forward, eating newlines (since `\s` includes newlines), but does nothing to update `self.lineno` as it goes. As a result, once a multiline array is parsed, `self.lineno` will be incorrect going forward for the rest of the file. 

I took a seriously hacky first pass at "fixing" this. I mostly meant to surface the underlying issue, adding hacks as I went (lots of redundancy in `ruby_parser_extras.rb` as I went). I don't truly understand most of how the parser works...so I have no confidence in saying my PoC is either complete and/or a vaguely preferable approach to solving the issue. 

Overall, I'm not really expecting you to merge this. I am mostly hoping that the code could surface the issue to someone much more familiar with the codebase so that it could be fixed more holistically/more cleanly (unless my hack is as good as it gets). This array literal bug is somewhat problematic for us, as multiline array literals are pretty common in our codebase. So, without a fix, we have a high probability of line comments being incorrect (especially since multiline arrays often sit at the top of source files, thus messing up every line number following). If you can't tell, I'm more or less begging for a fix :smile:. I'm more than happy to work with you to iterate on this PR if you don't have the time yourself. My fear in going it alone is that, to get to this point, I was more or less like a monkey on a keyboard, as I don't really understand how the parser works (other than vague recollections back to yacc, lex, and bison from school many years ago..hehe). So, if you could either take the reins or steer me it would be much appreciated. 

P.S. 
Unrelated to my fix, I also added a test for a multiline regular old array. These arrays more or less "worked". They seem to have an entirely different parsing flow from the `%w` style arrays (which makes sense). But, because of how they are created, you end up in a situation where the array s-expression isn't created until the first/last (depending on ruby versions) values in the array is parsed. As a result, the `self.lineno` that is used is the one that is associated with the actual element of the array rather than the array itself. I didn't attempt to resolve that, as I was most interested in checking/ensuring that the overall parser `self.lineno` was kept up to date as parsing occurred so that, even if the array itself isn't 100% "correct", it doesn't end up impacting all subsequent line numbers. 


/cc @presidentbeef @oreoshake @gregose @mastahyeti