### PR TITLE
Support Ruby 2.1 number literals

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -258,7 +258,18 @@ class RubyLexer
 
   def int_with_base base
     rb_compile_error "Invalid numeric format" if matched =~ /__/
-    return result(:expr_end, :tINTEGER, matched.to_i(base))
+
+    text = matched
+    case
+    when text.end_with?('ri')
+      return result(:expr_end, :tIMAGINARY, Complex(0, Rational(text.chop.chop.to_i(base))))
+    when text.end_with?('r')
+      return result(:expr_end, :tRATIONAL, Rational(text.chop.to_i(base)))
+    when text.end_with?('i')
+      return result(:expr_end, :tIMAGINARY, Complex(0, text.chop.to_i(base)))
+    else
+      return result(:expr_end, :tINTEGER, text.to_i(base))
+    end
   end
 
   def is_arg?
@@ -406,7 +417,17 @@ class RubyLexer
 
   def process_float text
     rb_compile_error "Invalid numeric format" if text =~ /__/
-    return result(:expr_end, :tFLOAT, text.to_f)
+
+    case
+    when text.end_with?('ri')
+      return result(:expr_end, :tIMAGINARY, Complex(0, Rational(text.chop.chop)))
+    when text.end_with?('r')
+      return result(:expr_end, :tRATIONAL, Rational(text.chop))
+    when text.end_with?('i')
+      return result(:expr_end, :tIMAGINARY, Complex(0, text.chop.to_f))
+    else
+      return result(:expr_end, :tFLOAT, text.to_f)
+    end
   end
 
   def process_gvar text

--- a/lib/ruby_lexer.rex
+++ b/lib/ruby_lexer.rex
@@ -12,12 +12,12 @@ macro
   SIMPLE_STRING /(#{ESC}|\#(#{ESC}|[^\{\#\@\$\"\\])|[^\"\\\#])*/o
   SSTRING       /(\\.|[^\'])*/
 
-  INT_DEC       /[+]?(?:(?:[1-9][\d_]*|0)(?!\.\d)\b|0d[0-9_]+)/i
-  INT_HEX       /[+]?0x[a-f0-9_]+/i
-  INT_BIN       /[+]?0b[01_]+/i
-  INT_OCT       /[+]?0o?[0-7_]+|0o/i
-  FLOAT         /[+]?\d[\d_]*\.[\d_]+(e[+-]?[\d_]+)?\b|[+]?[\d_]+e[+-]?[\d_]+\b/i
-  INT_DEC2      /[+]?\d[0-9_]*(?![e])/i
+  INT_DEC       /[+]?(?:(?:[1-9][\d_]*|0)(?!\.\d)(ri|r|i)?\b|0d[0-9_]+)(ri|r|i)?/i
+  INT_HEX       /[+]?0x[a-f0-9_]+(ri|r|i)?/i
+  INT_BIN       /[+]?0b[01_]+(ri|r|i)?/i
+  INT_OCT       /[+]?0o?[0-7_]+(ri|r|i)?|0o(ri|r|i)?/i
+  FLOAT         /[+]?\d[\d_]*\.[\d_]+(e[+-]?[\d_]+)?(ri|r|i)?\b|[+]?[\d_]+e[+-]?[\d_]+(ri|r|i)?\b/i
+  INT_DEC2      /[+]?\d[0-9_]*(?![e])((ri|r|i)\b)?/i
 
   NUM_BAD       /[+]?0[xbd]\b/i
   INT_OCT_BAD   /[+]?0o?[0-7_]*[89]/i

--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -27,10 +27,10 @@ token kCLASS kMODULE kDEF kUNDEF kBEGIN kRESCUE kENSURE kEND kIF kUNLESS
       tWORDS_BEG tQWORDS_BEG tSTRING_DBEG tSTRING_DVAR tSTRING_END
       tSTRING tSYMBOL tNL tEH tCOLON tCOMMA tSPACE tSEMI tLAMBDA
       tLAMBEG tDSTAR tCHAR tSYMBOLS_BEG tQSYMBOLS_BEG tSTRING_DEND tUBANG
-#if defined(RUBY21) || defined(RUBY22) || defined(RUBY23))
+#if defined(RUBY21) || defined(RUBY22) || defined(RUBY23)
       tRATIONAL tIMAGINARY
 #endif
-#if defined(RUBY22 || defined(RUBY23))
+#if defined(RUBY22) || defined(RUBY23)
       tLABEL_END
 #endif
 #if defined(RUBY23)
@@ -720,7 +720,7 @@ rule
                       result = new_call(new_call(s(:lit, val[1]), :"**", argl(val[3])), :"-@")
                     }
                 | tUMINUS_NUM tFLOAT tPOW arg
-#elif defined(RUBY21) || defined(RUBY22 || defined(RUBY23))
+#elif defined(RUBY21) || defined(RUBY22) || defined(RUBY23)
                 | tUMINUS_NUM simple_numeric tPOW arg
 #endif
                     {
@@ -1973,7 +1973,7 @@ regexp_contents: none
          numeric: tINTEGER
                 | tFLOAT
                 | tUMINUS_NUM tINTEGER =tLOWEST
-#elif defined(RUBY21) || defined(RUBY22 || defined(RUBY23))
+#elif defined(RUBY21) || defined(RUBY22) || defined(RUBY23)
          numeric: simple_numeric
                 | tUMINUS_NUM simple_numeric
 #endif
@@ -1987,7 +1987,7 @@ regexp_contents: none
 #endif
                     }
 
-#if defined(RUBY21) || defined(RUBY22) || defined(RUBY23))
+#if defined(RUBY21) || defined(RUBY22) || defined(RUBY23)
   simple_numeric: tINTEGER
                 | tFLOAT
                 | tRATIONAL
@@ -2186,7 +2186,7 @@ keyword_variable: kNIL      { result = s(:nil)   }
                       result = identifier
                     }
 
-#if defined(RUBY22) || defined(RUBY23))
+#if defined(RUBY22) || defined(RUBY23)
       f_arg_asgn: f_norm_arg
 
       f_arg_item: f_arg_asgn

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3505,6 +3505,13 @@ class TestRuby23Parser < RubyParserTestCase
 
     assert_parse rb, pt
   end
+
+  def test_ruby21_numbers
+    rb = "[1i, 2r, 3ri]"
+    pt = s(:array, s(:lit, Complex(0, 1)), s(:lit, Rational(2)), s(:lit, Complex(0, Rational(3))))
+
+    assert_parse rb, pt
+  end
 end
 
 


### PR DESCRIPTION
This PR is to add support for Ruby 2.1 rational and imaginary number literals;`1i`, `2r`, and `3ri`.

I know this patch has some incompatibility with ruby for succeeding `if`s.

```rb
1.0if true
```

is a correct ruby program which is parsed as a float literal with `if` modifier. But the lexer in this patch does not handle correctly. (I believe having this incompatibility is much better than not at all supported.)