### PR TITLE
Allow `if` expression as assoc value in call

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -788,7 +788,7 @@ class RubyLexer
       else
         result(state, :kDO, value)
       end
-    when in_lex_state?(:expr_beg, :expr_value) then # TODO: :expr_labelarg
+    when in_lex_state?(:expr_beg, :expr_value, :expr_labelarg) then
       result(state, keyword.id0, value)
     when keyword.id0 != keyword.id1 then
       result(:expr_beg, keyword.id1, value)

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2083,6 +2083,13 @@ module TestRubyParserShared19to22
     assert_parse rb, pt
   end
 
+  def test_call_assoc_new_if_multiline
+    rb = "a(b: if :c\n1\nelse\n2\nend)"
+    pt = s(:call, nil, :a, s(:hash, s(:lit, :b), s(:if, s(:lit, :c), s(:lit, 1), s(:lit, 2))))
+
+    assert_parse rb, pt
+  end
+
   def test_do_lambda
     rb = "->() do end"
     pt = s(:iter, s(:call, nil, :lambda), s(:args))


### PR DESCRIPTION
Meant to report this a long time ago from https://github.com/presidentbeef/brakeman/issues/916

Fixes parsing this:

```ruby
a(b: if c
       d  
     else
       e   
     end)
```

The root cause appears to be `if` being treated as `kIF_MOD` instead of `kIF`. `kIF_MOD` doesn't match any expressions so the parsing of the arg value fails.

Essentially doing the `TODO` appears to have fixed this so that `kIF` is chosen. Tests pass?