### PR TITLE
Parse squiqqly heredoc https://github.com/ruby/ruby/commit/9a28a29b870b5f45d370bc8f16c431b435f0bbb3

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -203,7 +203,7 @@ class RubyLexer
     self.string_buffer = []
 
     case
-    when scan(/(-?)([\'\"\`])(.*?)\2/) then
+    when scan(/([-~]?)([\'\"\`])(.*?)\2/) then
       term = ss[2]
       func |= STR_FUNC_INDENT unless ss[1].empty?
       func |= case term
@@ -215,9 +215,9 @@ class RubyLexer
                 STR_XQUOTE
               end
       string_buffer << ss[3]
-    when scan(/-?([\'\"\`])(?!\1*\Z)/) then
+    when scan(/[-~]?([\'\"\`])(?!\1*\Z)/) then
       rb_compile_error "unterminated here document identifier"
-    when scan(/(-?)(#{IDENT_CHAR}+)/) then
+    when scan(/([-~]?)(#{IDENT_CHAR}+)/) then
       term = '"'
       func |= STR_DQUOTE
       unless ss[1].empty? then

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -1140,6 +1140,17 @@ class TestRubyLexer < Minitest::Test
                 :tNL,             nil,             :expr_beg)
   end
 
+  def test_yylex_squiggly_heredoc_double_dash
+    assert_lex3("a = <<~\"EOF\"\n  blah blah\n  EOF\n\n",
+                nil,
+                :tIDENTIFIER,     "a",             :expr_cmdarg,
+                :tEQL,            "=",             :expr_beg,
+                :tSTRING_BEG,     "\"",            :expr_beg,
+                :tSTRING_CONTENT, "  blah blah\n", :expr_beg,
+                :tSTRING_END,     "EOF",           :expr_end,
+                :tNL,             nil,             :expr_beg)
+  end
+
   def test_yylex_heredoc_double_eos
     refute_lex("a = <<\"EOF\"\nblah",
                :tIDENTIFIER, "a",
@@ -1210,6 +1221,17 @@ class TestRubyLexer < Minitest::Test
                 :tNL,             nil,            :expr_beg)
   end
 
+  def test_yylex_squiggly_heredoc_none_dash
+    assert_lex3("a = <<~EOF\nblah\nblah\n  EOF\n",
+                nil,
+                :tIDENTIFIER,     "a",            :expr_cmdarg,
+                :tEQL,            "=",            :expr_beg,
+                :tSTRING_BEG,     "\"",           :expr_beg,
+                :tSTRING_CONTENT, "blah\nblah\n", :expr_beg,
+                :tSTRING_END,     "EOF",          :expr_end,
+                :tNL,             nil,            :expr_beg)
+  end
+
   def test_yylex_heredoc_single
     assert_lex3("a = <<'EOF'\n  blah blah\nEOF\n\n",
                 nil,
@@ -1251,6 +1273,17 @@ class TestRubyLexer < Minitest::Test
 
   def test_yylex_heredoc_single_dash
     assert_lex3("a = <<-'EOF'\n  blah blah\n  EOF\n\n",
+                nil,
+                :tIDENTIFIER,     "a",             :expr_cmdarg,
+                :tEQL,            "=",             :expr_beg,
+                :tSTRING_BEG,     "\"",            :expr_beg,
+                :tSTRING_CONTENT, "  blah blah\n", :expr_beg,
+                :tSTRING_END,     "EOF",           :expr_end,
+                :tNL,             nil,             :expr_beg)
+  end
+
+  def test_yylex_squiggly_heredoc_single_dash
+    assert_lex3("a = <<~'EOF'\n  blah blah\n  EOF\n\n",
                 nil,
                 :tIDENTIFIER,     "a",             :expr_cmdarg,
                 :tEQL,            "=",             :expr_beg,

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -834,9 +834,41 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_parse_line_squiggly_heredoc
+    rb = <<-CODE
+      string = <<~HEREDOC
+        very long string
+      HEREDOC
+      puts string
+    CODE
+
+    pt = s(:block,
+           s(:lasgn, :string,
+             s(:str, "        very long string\n").line(1)).line(1),
+           s(:call, nil, :puts, s(:lvar, :string).line(4)).line(4)).line(1)
+
+    assert_parse rb, pt
+  end
+
   def test_parse_line_heredoc_regexp_chars
     rb = <<-CODE
       string = <<-"^D"
+        very long string
+      ^D
+      puts string
+    CODE
+
+    pt = s(:block,
+           s(:lasgn, :string,
+             s(:str, "        very long string\n").line(1)).line(1),
+           s(:call, nil, :puts, s(:lvar, :string).line(4)).line(4)).line(1)
+
+    assert_parse rb, pt
+  end
+
+  def test_parse_line_squiggly_heredoc_regexp_chars
+    rb = <<-CODE
+      string = <<~"^D"
         very long string
       ^D
       puts string


### PR DESCRIPTION
This should fix https://github.com/seattlerb/ruby_parser/issues/218.

I'm not sure if all of the heredoc tests really need to be duplicated for this fix or not.