### PR TITLE
Fallback to the latest ruby version

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -1501,7 +1501,8 @@ class RubyParser
     when /^2.3/ then
       Ruby23Parser.new
     else
-      raise "unrecognized RUBY_VERSION #{RUBY_VERSION}"
+      warning('Ruby version not supported. Using the latest one.')
+      Ruby23Parser.new
     end
   end
 end


### PR DESCRIPTION
I'm currently running ruby 2.4.0 and fasterer is failing because ruby_parser does not support it. And I think the version 2.3 is closer enough to the 2.4 syntax to it works.

Don't know if this PR is a valid one.
It makes the default return of the `for_current_ruby` method aways the latest ruby version, with a warning.

Thanks 🍻 