### PR TITLE
Properly handle kDO with no-parens stabby lambda

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -778,7 +778,7 @@ class RubyLexer
       when lpar_beg && lpar_beg == paren_nest then
         self.lpar_beg = nil
         self.paren_nest -= 1
-        result(state, :kDO_LAMBDA, value)
+        expr_result(:kDO_LAMBDA, value)
       when cond.is_in_state then
         result(state, :kDO_COND, value)
       when cmdarg.is_in_state && lex_state != :expr_cmdarg then

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2339,6 +2339,30 @@ module TestRubyParserShared20to22
 
     assert_parse rb, pt
   end
+
+  def test_stabby_block_iter_call
+    rb = "x -> () do\na.b do\nend\nend"
+    pt = s(:call, nil, :x,
+           s(:iter,
+             s(:call, nil, :lambda),
+             s(:args),
+             s(:iter, s(:call, s(:call, nil, :a), :b), 0)))
+
+    assert_parse rb, pt
+  end
+
+  def test_stabby_block_iter_call_no_target_with_arg
+    rb = "x -> () do\na(1) do\nend\nend"
+    pt = s(:call, nil, :x,
+           s(:iter,
+             s(:call, nil, :lambda),
+             s(:args),
+             s(:iter,
+               s(:call, nil, :a,
+                 s(:lit, 1)), 0)))
+
+    assert_parse rb, pt
+  end
 end
 
 class TestRubyParser < Minitest::Test


### PR DESCRIPTION
This code causes a parsing error:

```ruby
x -> () do
  a.b do
  end
end
```

Of importance: no parens around stabby lambda, `do`/`end` used for both blocks, `a.b` must be a method call (not a command).

Also fixes #192 

Before:

```
2.3.1 :001 > require 'ruby_parser'
 => true 
2.3.1 :002 > Ruby23Parser.new.parse <<RUBY
2.3.1 :003"> x ->() do
2.3.1 :004">   a.b do
2.3.1 :005">   end
2.3.1 :006"> end
2.3.1 :007"> RUBY
Racc::ParseError: (string):2 :: parse error on value ["do", 2] (kDO_BLOCK)
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/racc/parser.rb:528:in `on_error'
	from /home/justin/.rvm/gems/ruby-2.3.1@brakeman/gems/ruby_parser-3.8.4/lib/ruby_parser_extras.rb:1227:in `on_error'
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/racc/parser.rb:259:in `_racc_do_parse_c'
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/racc/parser.rb:259:in `do_parse'
	from /home/justin/.rvm/gems/ruby-2.3.1@brakeman/gems/ruby_parser-3.8.4/lib/ruby_parser_extras.rb:1139:in `block in process'
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:91:in `block in timeout'
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:33:in `block in catch'
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:33:in `catch'
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:33:in `catch'
	from /home/justin/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:106:in `timeout'
	from /home/justin/.rvm/gems/ruby-2.3.1@brakeman/gems/ruby_parser-3.8.4/lib/ruby_parser_extras.rb:1127:in `process'
	from (irb):2
	from /home/justin/.rvm/rubies/ruby-2.3.1/bin/irb:11:in `<main>'
```

After:

```
2.3.1 :001 > require 'ruby_parser'
 => true 
2.3.1 :002 > Ruby23Parser.new.parse <<RUBY
2.3.1 :003"> x ->() do
2.3.1 :004">   a.b do
2.3.1 :005">   end
2.3.1 :006"> end
2.3.1 :007"> RUBY
 => s(:call, nil, :x, s(:iter, s(:call, nil, :lambda), s(:args), s(:iter, s(:call, s(:call, nil, :a), :b), 0)))
```

This change removes `cmdarg` from stack when setting `kDO_LAMBDA`.