### PR TITLE
Copy cmdargs for `defs`

### DIFF
--- a/lib/ruby19_parser.y
+++ b/lib/ruby19_parser.y
@@ -1133,15 +1133,21 @@ rule
                     }
                     fname
                     {
+                      result = self.lexer.cmdarg.stack.dup
+
                       self.in_single += 1
                       self.env.extend
+                      lexer.cmdarg.stack.replace [false]
                       lexer.lex_state = :expr_end # force for args
-                      result = lexer.lineno
                     }
                     f_arglist bodystmt kEND
                     {
+                      cmdarg = val[5]
+
                       result = new_defs val
                       result[3].line val[5]
+
+                      lexer.cmdarg.stack.replace cmdarg
 
                       self.env.unextend
                       self.in_single -= 1

--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1222,15 +1222,21 @@ rule
                     }
                     fname
                     {
+                      result = self.lexer.cmdarg.stack.dup
+
                       self.in_single += 1
                       self.env.extend
                       lexer.lex_state = :expr_endfn # force for args
-                      result = lexer.lineno
+                      lexer.cmdarg.stack.replace [false]
                     }
                     f_arglist bodystmt kEND
                     {
+                      cmdarg = val[5]
+
                       result = new_defs val
                       result[3].line val[5]
+
+                      lexer.cmdarg.stack.replace cmdarg
 
                       self.env.unextend
                       self.in_single -= 1

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1838,6 +1838,17 @@ module TestRubyParserShared19Plus
     assert_parse rb, pt
   end
 
+  def test_defs_as_arg_with_do_block_inside
+    rb = "a def self.b\n x.y do\n end\n end"
+    pt = s(:call,
+           nil,
+           :a,
+           s(:defs, s(:self), :b, s(:args),
+             s(:iter, s(:call, s(:call, nil, :x), :y), 0)))
+
+    assert_parse rb, pt
+  end
+
   def test_defn_opt_reg
     rb = "def f(a=nil, b) end"
     pt = s(:defn, :f, s(:args, s(:lasgn, :a, s(:nil)), :b), s(:nil))


### PR DESCRIPTION
I don't really know what I'm doing, I just copied what @zenspider did in  adeceebf04f03bd0a878201fbf5979111acaa26f to handle this for `def`.

Fixes #213 as well as provides a minimal test.