### PR TITLE
Restore newline after label to detect required kwarg

### DIFF
--- a/lib/ruby19_parser.y
+++ b/lib/ruby19_parser.y
@@ -2079,10 +2079,10 @@ keyword_variable: kNIL      { result = s(:nil)   }
                     {
                       result = s(:array, val[0], val[2])
                     }
-                | tLABEL arg_value
+                | tLABEL opt_nl arg_value
                     {
                       label, _ = val[0] # TODO: fix lineno?
-                      result = s(:array, s(:lit, label.to_sym), val[1])
+                      result = s(:array, s(:lit, label.to_sym), val.last)
                     }
 
        operation: tIDENTIFIER | tCONSTANT | tFID

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -548,7 +548,7 @@ class RubyLexer
     self.lineno += matched.lines.to_a.size if scan(/\n+/)
 
     return if in_lex_state?(:expr_beg, :expr_value, :expr_class,
-                            :expr_fname, :expr_dot, :expr_labelarg)
+                            :expr_fname, :expr_dot)
 
     if scan(/([\ \t\r\f\v]*)(\.|&)/) then
       self.space_seen = true unless ss[1].empty?

--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -2418,9 +2418,9 @@ keyword_variable: kNIL      { result = s(:nil)   }
                     {
                       result = s(:array, val[0], val[2])
                     }
-                | tLABEL arg_value
+                | tLABEL opt_nl arg_value
                     {
-                      result = s(:array, s(:lit, val[0][0].to_sym), val[1])
+                      result = s(:array, s(:lit, val[0][0].to_sym), val.last)
                     }
 #if V >= 22
                 | tSTRING_BEG string_contents tLABEL_END arg_value

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2797,6 +2797,20 @@ class TestRubyLexer < Minitest::Test
                :tRCURLY, "}", :expr_endarg,   0, 0)
   end
 
+  def test_yylex_required_kwarg_no_value_22
+    setup_lexer_class RubyParser::V22
+
+    assert_lex3("def foo a:, b:\nend",
+                nil,
+                :kDEF, "def", :expr_fname,
+                :tIDENTIFIER, "foo", :expr_endfn,
+                :tLABEL, "a",   :expr_labelarg,
+                :tCOMMA, ",", :expr_beg,
+                :tLABEL, "b",   :expr_labelarg,
+                :tNL, nil, :expr_beg,
+                :kEND, "end", :expr_end)
+  end
+
   def test_ruby21_rational_literal
     setup_lexer_class RubyParser::V21
 

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3419,6 +3419,17 @@ module TestRubyParserShared23Plus
     assert_parse rb, pt
   end
 
+  def test_required_kwarg_no_value
+    rb = "def x a:, b:\nend"
+    pt = s(:defn, :x,
+           s(:args,
+             s(:kwarg, :a),
+             s(:kwarg, :b)),
+           s(:nil))
+
+    assert_parse rb, pt
+  end
+
   def test_slashy_newlines_within_string
     rb = %(puts "hello\\
  my\\


### PR DESCRIPTION
Handles this code:

```ruby
def x a:, b:
#...
end
```

The change is to keep the `tNL` token after a label (which reverts b025dc85) so that the end of the argument list can be detected with the newline at https://github.com/seattlerb/ruby_parser/blob/349052139dfc99ad4b345fe61db8ba3edc98adfb/lib/ruby_parser.yy#L2074

Unfortunately this means `opt_nl` needs to be added to allow newlines in after hash keys.

This may not be the best way to do this, but I don't see how to detect the difference between a label in a function parameter list and a label in a hash table.