### PR TITLE
Improve handling of single-quoted symbols and labels

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -745,7 +745,12 @@ class RubyLexer
   end
 
   def process_symbol text
-    symbol = match[1].gsub(ESC) { unescape $1 }
+    content = match[1]
+    if text =~ /^:"/
+      symbol = content.gsub(ESC) { unescape $1 }
+    else
+      symbol = content
+    end
 
     rb_compile_error "symbol cannot contain '\\0'" if
       ruby18 && symbol =~ /\0/

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -776,7 +776,11 @@ class RubyLexer
   end
 
   def process_label text
-    symbol = text[1..-3].gsub(ESC) { unescape $1 }
+    if text =~ /^"/
+      symbol = text[1..-3].gsub(ESC) { unescape $1 }
+    else
+      symbol = text[1..-3].gsub(/\\\\/, "\\").gsub(/\\'/, "'")
+    end
 
     result(:expr_labelarg, :tLABEL, [symbol, self.lineno])
   end

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -749,7 +749,7 @@ class RubyLexer
     if text =~ /^:"/
       symbol = content.gsub(ESC) { unescape $1 }
     else
-      symbol = content
+      symbol = content.gsub(/\\\\/, "\\").gsub(/\\'/, "'")
     end
 
     rb_compile_error "symbol cannot contain '\\0'" if

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2598,6 +2598,10 @@ class TestRubyLexer < Minitest::Test
     assert_lex3("'blah\\\nblah'", nil, :tSTRING, "blah\\\nblah", :expr_end)
   end
 
+  def test_yylex_string_single_escaped_quote
+    assert_lex3("'foo\\'bar'", nil, :tSTRING, "foo'bar", :expr_end)
+  end
+
   def test_yylex_symbol
     assert_lex3(":symbol", nil, :tSYMBOL, "symbol", :expr_end)
   end
@@ -2645,6 +2649,10 @@ class TestRubyLexer < Minitest::Test
     assert_lex3(":'s\\tri\\ng'",
                 nil,
                 :tSYMBOL,   "s\\tri\\ng", :expr_end)
+  end
+
+  def test_yylex_string_single_escape_quote_and_backslash
+    assert_lex3(":'foo\\'bar\\\\baz'", nil, :tSYMBOL, "foo'bar\\baz", :expr_end)
   end
 
   def test_yylex_ternary1

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2833,6 +2833,30 @@ class TestRubyLexer < Minitest::Test
                 :kEND, "end", :expr_end)
   end
 
+  def test_yylex_hash_colon_double_quoted_with_escapes
+    setup_lexer_class RubyParser::V22
+
+    assert_lex3("{\"s\\tr\\i\\ng\\\\foo\\'bar\":1}",
+               nil,
+
+               :tLBRACE, "{", :expr_beg,
+               :tLABEL,  "s\tr\i\ng\\foo'bar", :expr_labelarg,
+               :tINTEGER, 1,  :expr_end,
+               :tRCURLY, "}", :expr_endarg)
+  end
+
+  def test_yylex_hash_colon_quoted_with_escapes
+    setup_lexer_class RubyParser::V22
+
+    assert_lex3("{'s\\tr\\i\\ng\\\\foo\\'bar':1}",
+               nil,
+
+               :tLBRACE, "{", :expr_beg,
+               :tLABEL,  "s\\tr\\i\\ng\\foo'bar", :expr_labelarg,
+               :tINTEGER, 1,  :expr_end,
+               :tRCURLY, "}", :expr_endarg)
+  end
+
   def test_ruby21_rational_literal
     setup_lexer_class RubyParser::V21
 

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2641,6 +2641,12 @@ class TestRubyLexer < Minitest::Test
                 :tSYMBOL,   'symbol#{1+1}', :expr_end)
   end
 
+  def test_yylex_symbol_single_escape_chars
+    assert_lex3(":'s\\tri\\ng'",
+                nil,
+                :tSYMBOL,   "s\\tri\\ng", :expr_end)
+  end
+
   def test_yylex_ternary1
     assert_lex3("a ? b : c",
                 nil,


### PR DESCRIPTION
This handles single-quoted dsyms and labels differently from double-quoted ones.

Current behavior incorrectly unescapes, e.g., `\n`:
```
>> RubyParser.new.parse ":'foo\\n'" # => s(:lit, :"foo\n")
>> RubyParser.new.parse "{ 'foo\\n': 1 }" #=> s(:hash, s(:lit, :"foo\n"), s(:lit, 1))
```

Expected results are:

```
>> RubyParser.new.parse ":'foo\\n'" #=> s(:lit, :"foo\n") #=> s(:lit, :"foo\\n")
>> RubyParser.new.parse "{ 'foo\\n': 1 }" #=> s(:hash, s(:lit, :"foo\\n"), s(:lit, 1))
```