### PR TITLE
Allow rescue inside do/end blocks

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1660,7 +1660,11 @@ opt_block_args_tail: tCOMMA block_args_tail
                     {
                       result = nil # self.env.dynamic.keys
                     }
+#if V >= 25
+                    bodystmt kEND
+#else
                     compstmt kEND
+#endif
                     {
                       _, line, args, _, body, _ = val
 

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3766,6 +3766,72 @@ class TestRubyParserV25 < RubyParserTestCase
 
     self.processor = RubyParser::V25.new
   end
+
+  def test_rescue_in_block
+    rb = "blah do\nrescue\nstuff\nend"
+    pt = s(:iter, s(:call, nil, :blah), 0, s(:rescue, s(:resbody, s(:array), s(:call, nil, :stuff))))
+    assert_parse rb, pt
+  end
+
+  def test_rescue_do_end_raised
+    rb = "tap do\n raise\n ensure\n :ensure\n end"
+    pt = s(:iter,
+           s(:call, nil, :tap),
+           0,
+           s(:ensure,
+             s(:call, nil, :raise),
+             s(:lit, :ensure)))
+
+    assert_parse rb, pt
+  end
+
+  def test_rescue_do_end_rescued
+    rb = "tap do\n raise\n rescue\n :rescue\n else\n :else\n ensure\n :ensure\n end"
+    pt = s(:iter,
+           s(:call, nil, :tap),
+           0,
+           s(:ensure,
+             s(:rescue,
+               s(:call, nil, :raise),
+               s(:resbody,
+                 s(:array),
+                 s(:lit, :rescue)),
+               s(:lit, :else)),
+             s(:lit, :ensure)))
+
+    assert_parse rb, pt
+  end
+
+  def test_rescue_do_end_no_raise
+    rb = "tap do\n :begin\n rescue\n :rescue\n else\n :else\n ensure\n :ensure\n end"
+    pt = s(:iter,
+           s(:call, nil, :tap),
+           0,
+           s(:ensure,
+             s(:rescue,
+               s(:lit, :begin),
+               s(:resbody,
+                 s(:array),
+                 s(:lit, :rescue)),
+               s(:lit, :else)),
+             s(:lit, :ensure)))
+
+    assert_parse rb, pt
+  end
+
+  def test_rescue_do_end_ensure_result
+    rb = "proc do\n :begin\n ensure\n :ensure\n end.call"
+    pt = s(:call,
+           s(:iter,
+             s(:call, nil, :proc),
+             0,
+             s(:ensure,
+               s(:lit, :begin),
+               s(:lit, :ensure))),
+           :call)
+
+    assert_parse rb, pt
+  end
 end
 
 RubyParser::VERSIONS.each do |klass|


### PR DESCRIPTION
Just copied https://github.com/ruby/ruby/commit/0ec889d7ed34f80b534dfc7a93bdd3175aba9ff9 although I'm not really sure why `brace_block` needs to change and `do_block` doesn't.

Addresses #262