### PR TITLE
Stabby proc with do/end as block call argument

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -865,6 +865,8 @@ class RubyLexer
         result(state, :kDO_BLOCK, value)
       when in_lex_state?(:expr_beg, :expr_endarg) then
         result(state, :kDO_BLOCK, value)
+      when lex_state == :expr_end # do end do end
+        result(state, :kDO_BLOCK, value)
       else
         result(state, :kDO, value)
       end

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -494,6 +494,20 @@ class TestRubyLexer < Minitest::Test
                :tRCURLY,     "}", :expr_endarg, 0, 0)
   end
 
+  def test_yylex_lambda_as_args_with_block__20
+    setup_lexer_class RubyParser::V20
+
+    assert_lex3("a -> do end do end",
+                nil,
+               :tIDENTIFIER, "a", :expr_cmdarg,
+               :tLAMBDA,     nil, :expr_endfn,
+               :kDO, "do", :expr_beg,
+               :kEND, "end", :expr_end,
+               :kDO_BLOCK, "do", :expr_beg,
+               :kEND, "end", :expr_end
+              )
+  end
+
   def test_yylex_lambda_args_opt__20
     setup_lexer_class RubyParser::V20
 

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -2029,6 +2029,20 @@ module TestRubyParserShared19Plus
     assert_parse rb, pt
   end
 
+  def test_call_stabby_with_braces_block
+    rb = "a -> {} do\nend"
+    pt = s(:iter, s(:call, nil, :a, s(:iter, s(:call, nil, :lambda), 0)), 0)
+
+    assert_parse rb, pt
+  end
+
+  def test_call_stabby_do_end_with_block
+    rb = "a -> do end do end"
+    pt = s(:iter, s(:call, nil, :a, s(:iter, s(:call, nil, :lambda), 0)), 0)
+
+    assert_parse rb, pt
+  end
+
   def test_call_trailing_comma
     rb = "f(1,)"
     pt = s(:call, nil, :f, s(:lit, 1))


### PR DESCRIPTION
In order to parse this:

```ruby
a -> do end do end
```

Lexer state is sufficient to distinguish this from

```ruby
a -> do end
do end
```

which does not and should not parse.

Fixes #266