### PR TITLE
Performance improvements via reducing string allocations

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -896,26 +896,26 @@ class RubyLexer
   def read_escape # TODO: remove / rewrite
     case
     when scan(/\\/) then                  # Backslash
-      '\\'
+      '\\'.dup
     when scan(/n/) then                   # newline
       self.extra_lineno -= 1
-      "\n"
+      "\n".dup
     when scan(/t/) then                   # horizontal tab
-      "\t"
+      "\t".dup
     when scan(/r/) then                   # carriage-return
-      "\r"
+      "\r".dup
     when scan(/f/) then                   # form-feed
-      "\f"
+      "\f".dup
     when scan(/v/) then                   # vertical tab
-      "\13"
+      "\13".dup
     when scan(/a/) then                   # alarm(bell)
-      "\007"
+      "\007".dup
     when scan(/e/) then                   # escape
-      "\033"
+      "\033".dup
     when scan(/b/) then                   # backspace
-      "\010"
+      "\010".dup
     when scan(/s/) then                   # space
-      " "
+      " ".dup
     when scan(/[0-7]{1,3}/) then          # octal constant
       (matched.to_i(8) & 0xFF).chr
     when scan(/x([0-9a-fA-F]{1,2})/) then # hex constant
@@ -948,7 +948,7 @@ class RubyLexer
       rb_compile_error("Invalid escape character syntax")
     else
       ss.getch
-    end.dup
+    end
   end
 
   def regx_options # TODO: rewrite / remove

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 
 $DEBUG = true if ENV["DEBUG"]
@@ -947,7 +948,7 @@ class RubyLexer
       rb_compile_error("Invalid escape character syntax")
     else
       ss.getch
-    end
+    end.dup
   end
 
   def regx_options # TODO: rewrite / remove

--- a/lib/ruby_parser.rb
+++ b/lib/ruby_parser.rb
@@ -12,12 +12,19 @@ class RubyParser
   class Parser < Racc::Parser
     include RubyParserStuff
 
+    @version = nil
+
     def self.inherited x
+      x.version = x.name[/(?:V|Ruby)(\d+)/, 1].to_i
       RubyParser::VERSIONS << x
     end
 
+    def self.version= v
+       @version = v
+    end
+
     def self.version
-      Parser > self and self.name[/(?:V|Ruby)(\d+)/, 1].to_i
+      @version
     end
   end
 

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -1358,9 +1358,11 @@ module RubyParserStuff
 
     def push val
       @stack.push val
-      c = caller.first
-      c = caller[1] if c =~ /expr_result/
-      warn "#{name}_stack(push): #{val} at line #{c.clean_caller}" if debug
+      if debug
+        c = caller.first
+        c = caller[1] if c =~ /expr_result/
+        warn "#{name}_stack(push): #{val} at line #{c.clean_caller}"
+      end
       nil
     end
 

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -1012,7 +1012,7 @@ module RubyParserStuff
     has_enc = str.respond_to? :encoding
     encoding = nil
 
-    header = str.lines.first(2)
+    header = str.each_line.first(2)
     header.map! { |s| s.force_encoding "ASCII-8BIT" } if has_enc
 
     first = header.first || ""


### PR DESCRIPTION
Found some low-hanging fruit for performance improvements. Each one is a separate commit and can be merged independently.

The biggest gain was moving some code apparently only used for a debug message to behind the debug flag.

The next biggest was not re-calculating the parser version every time `RubyParser::Parser.version` is called. It's called *a lot* in the lexer.

Freezing strings in the lexer provided a nice allocation reduction but not much difference in time, probably because they are tiny strings.

Finally, I changed the code in `handle_encoding` used to grab potential encoding headers. It was splitting the entire file into lines just to grab the first two. Only happens once, so not a big impact, but still unnecessary.

| Change | String Allocation Reduction | Time Reduction |
|-|-|-|
| Wrap debug | 38-52% | 20-26% |
| Cache version number | 24% | 5-11% |
| Freeze strings in lexer | 24-30% | meh |
| Grabbing header | 0.5-2% | meh |
| **Total** | **75-83%** | **30-37%**  |

Running Rake test:

4s -> 2.7s (~33% faster)

I used ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux] for testing.

I'm a little nervous about the frozen strings, but I tested the changes with Brakeman across my corpus of 434 Rails apps without issue.