### PR TITLE
Parse error with shadowed method name and a block call

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -836,7 +836,14 @@ class RubyLexer
 
     if not [:expr_dot, :expr_fname].include? last_state and
         self.parser.env[token.to_sym] == :lvar then
-      state = :expr_end
+
+      if command_state
+        if ss.match?(/\s+\[/) # a = []; a [1]
+          state = :expr_end
+        end
+      else
+        state = :expr_end
+      end
     end
 
     token.lineno = self.lineno # yes, on a string. I know... I know...

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1045,6 +1045,15 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_iter_shadowed_method_name
+    rb = "x = 1; x do end"
+    pt = s(:block,
+           s(:lasgn, :x, s(:lit, 1)),
+           s(:iter, s(:call, nil, :x), 0))
+
+    assert_parse rb, pt
+  end
+
   def test_str_heredoc_interp
     rb = "<<\"\"\n\#{x}\nblah2\n\n"
     pt = s(:dstr, "", s(:evstr, s(:call, nil, :x)), s(:str, "\nblah2\n"))


### PR DESCRIPTION
I appear to have introduced a regression with 9f89182312e8438e6c7524233bcc05a6f5e7fd05.

Code like this:

```ruby
def a
  yield
end

def x(a)
  a do # Calls `a` method, not `a` argument
    puts a # Prints `a` argument
  end
end
```

Actually works (to my amazement) but it no longer parses correctly with RubyParser 3.12.0. This is only a problem when the method called for the block is the same name as a local or argument variable.

Haven't investigated a fix yet.