### PR TITLE
Fix rescue modifier handling for Ruby >= 2.4

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -253,6 +253,12 @@ rule
                     {
                       result = new_assign val[0], val[2]
                     }
+#if V >= 24
+                | lhs tEQL command_call kRESCUE_MOD arg
+                    {
+                      result = new_assign val[0], s(:rescue, val[2], new_resbody(s(:array), val[4]))
+                    }
+#endif
                 | lhs tEQL command_asgn
                     {
                       result = new_assign val[0], val[2]

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1277,6 +1277,16 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_lasgn_call_bracket_rescue_arg
+    rb = "a = b(1) rescue 2"
+    pt = s(:lasgn, :a,
+           s(:rescue,
+             s(:call, nil, :b, s(:lit, 1)),
+             s(:resbody, s(:array), s(:lit, 2))))
+
+    assert_parse rb, pt
+  end
+
   def test_call_bang_squiggle
     rb = "1 !~ 2"
     pt = s(:not, s(:call, s(:lit, 1), :=~, s(:lit, 2))) # TODO: check for 1.9+
@@ -3472,7 +3482,15 @@ a + b
 end
 
 module TestRubyParserShared24Plus
-  # ...version specific tests to go here...
+  def test_lasgn_call_nobracket_rescue_arg
+    rb = "a = b 1 rescue 2"
+    pt = s(:lasgn, :a,
+           s(:rescue,
+             s(:call, nil, :b, s(:lit, 1)),
+             s(:resbody, s(:array), s(:lit, 2))))
+
+    assert_parse rb, pt
+  end
 end
 
 module TestRubyParserShared25Plus
@@ -3746,6 +3764,15 @@ class TestRubyParserV23 < RubyParserTestCase
     super
 
     self.processor = RubyParser::V23.new
+  end
+
+  def test_lasgn_call_nobracket_rescue_arg
+    rb = "a = b 1 rescue 2"
+    pt = s(:rescue,
+          s(:lasgn, :a, s(:call, nil, :b, s(:lit, 1))),
+          s(:resbody, s(:array), s(:lit, 2)))
+
+    assert_parse rb, pt
   end
 end
 


### PR DESCRIPTION
Ruby 2.4 fixed handling of the rescue modifier for the case of a method call without brackets, e.g.:

```ruby
foo = bar baz rescue qux
```

This is basically a port of https://github.com/ruby/ruby/commit/064ed74.

This fixes #227.