### PR TITLE
Make all string literals UTF-8 if possible

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -1178,7 +1178,6 @@ class RubyLexer
         else
           s
         end
-    x.force_encoding "UTF-8" if HAS_ENC
     x
   end
 

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -804,6 +804,7 @@ module RubyParserStuff
 
   def new_string val
     str = val[0]
+    str.force_encoding("UTF-8")
     str.force_encoding("ASCII-8BIT") unless str.valid_encoding?
     result = s(:str, str)
     self.lexer.fixup_lineno str.count("\n")

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -2300,7 +2300,6 @@ class TestRubyLexer < Minitest::Test
 
   def test_yylex_string_double_escape_M
     chr = "\341"
-    chr.force_encoding("UTF-8") if RubyLexer::HAS_ENC
 
     assert_lex3("\"\\M-a\"", nil, :tSTRING, chr, :expr_end)
   end

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -499,6 +499,14 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_str_evstr_escape
+    char = [0x00bd].pack("U")
+    rb = "\"a #\{b}\\302\\275\""
+    pt = s(:dstr, "a ", s(:evstr, s(:call, nil, :b)), s(:str, char))
+
+    assert_parse rb, pt
+  end
+
   def test_dsym_to_sym
     pt = s(:alias, s(:lit, :<<), s(:lit, :>>))
 


### PR DESCRIPTION
With the existing implementation, literal parts of strings that came after interpolations would not be forced to UTF-8, leading to the following inconsistency:

    >> RubyParser.new.parse '"2\302\275"'
    #=> s(:str, "2½")
    >> RubyParser.new.parse '"#{foo}2\302\275"'s
    #=> s(:dstr, "",
    #     s(:evstr, s(:call, nil, :foo)), s(:str, "2\xC2\xBD"))

This change moves forcing the encoding to the parser, ensuring that all generated :str nodes have their encoding adjusted.