### PR TITLE
Restore compatible rescue modifier handling for Ruby < 2.4

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -302,12 +302,14 @@ rule
                       expr, = val
                       result = value_expr expr
                     }
+#if V >= 24
                 | command_call kRESCUE_MOD stmt
                     {
                       expr, _, resbody = val
                       expr = value_expr expr
                       result = new_rescue(expr, new_resbody(s(:array), resbody))
                     }
+#endif
                 | command_asgn
 
             expr: command_call

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1259,6 +1259,16 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_lasgn_call_bracket_rescue_arg
+    rb = "a = b(1) rescue 2"
+    pt = s(:lasgn, :a,
+           s(:rescue,
+             s(:call, nil, :b, s(:lit, 1)),
+             s(:resbody, s(:array), s(:lit, 2))))
+
+    assert_parse rb, pt
+  end
+
   def test_call_bang_squiggle
     rb = "1 !~ 2"
     pt = s(:not, s(:call, s(:lit, 1), :=~, s(:lit, 2))) # TODO: check for 1.9+
@@ -3468,7 +3478,15 @@ end
 module TestRubyParserShared24Plus
   include TestRubyParserShared23Plus
 
-  # ...version specific tests to go here...
+  def test_lasgn_call_nobracket_rescue_arg
+    rb = "a = b 1 rescue 2"
+    pt = s(:lasgn, :a,
+           s(:rescue,
+             s(:call, nil, :b, s(:lit, 1)),
+             s(:resbody, s(:array), s(:lit, 2))))
+
+    assert_parse rb, pt
+  end
 end
 
 module TestRubyParserShared25Plus
@@ -3642,6 +3660,15 @@ class TestRubyParserV23 < RubyParserTestCase
     super
 
     self.processor = RubyParser::V23.new
+  end
+
+  def test_lasgn_call_nobracket_rescue_arg
+    rb = "a = b 1 rescue 2"
+    pt = s(:rescue,
+          s(:lasgn, :a, s(:call, nil, :b, s(:lit, 1))),
+          s(:resbody, s(:array), s(:lit, 2)))
+
+    assert_parse rb, pt
   end
 end
 


### PR DESCRIPTION
Ruby 2.4 fixed handling of the rescue modifier for the case of a method call without brackets, e.g.:

  foo = bar baz rescue qux

However, this fix was not backported to older Rubies, so RubyParser should parse those the old, broken way.

See also #273 and #227.