### PR TITLE
Fix line numbering for assigned value in op_asgn

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -802,15 +802,17 @@ module RubyParserStuff
     lhs, asgn_op, arg = val[0], val[1].to_sym, val[2]
     name = lhs.value
     arg = remove_begin(arg)
+    value = self.gettable(name)
+    value.line = lhs.line
     result = case asgn_op # REFACTOR
              when :"||" then
                lhs << arg
-               s(:op_asgn_or, self.gettable(name), lhs)
+               s(:op_asgn_or, value, lhs)
              when :"&&" then
                lhs << arg
-               s(:op_asgn_and, self.gettable(name), lhs)
+               s(:op_asgn_and, value, lhs)
              else
-               lhs << new_call(self.gettable(name), asgn_op, argl(arg))
+               lhs << new_call(value, asgn_op, argl(arg))
                lhs
              end
     result.line = lhs.line

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -844,6 +844,23 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_parse_line_op_asgn
+    rb = <<-CODE
+      foo += bar
+      baz
+    CODE
+
+    pt = s(:block,
+           s(:lasgn, :foo,
+             s(:call,
+               s(:lvar, :foo).line(1),
+               :+,
+               s(:call, nil, :bar).line(1)).line(1)).line(1),
+           s(:call, nil, :baz).line(2)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
   def test_parse_line_heredoc
     rb = <<-CODE
       string = <<-HEREDOC


### PR DESCRIPTION
Here's a first line numbering fix.

The current behavior is (with VERBOSE=true):

```ruby
RubyParser.for_current_ruby.parse("foo += bar\nbaz")
# => s(:block, s(:lasgn, :foo, s(:call, s(:lvar, :foo).line(2), :+,
#      s(:call, nil, :bar).line(1)).line(1)).line(1), s(:call, nil, :baz).line(2)).line(1)
```

Here, the added `s(:lvar, :foo)` gets line number 2, when it is part of an expression that is entirely on line 1.