### PR TITLE
Disallow BEGIN when not at top level

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -167,16 +167,7 @@ rule
    stmt_or_begin: stmt
                 | klBEGIN
                     {
-                      if (self.in_def || self.in_single > 0) then
-                        debug20 1
-                        yyerror "BEGIN in method"
-                      end
-                      self.env.extend
-                    }
-                    begin_block
-                    {
-                      _, _, stmt = val
-                      result = stmt
+                      yyerror "BEGIN is permitted only at toplevel"
                     }
 
             stmt: kALIAS fitem

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1630,6 +1630,13 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_BEGIN_not_toplevel
+    rb = "class Foo\nBEGIN {\n42\n}\nend"
+
+    assert_syntax_error rb, "BEGIN is permitted only at toplevel"
+  end
+
+
   def test_attrasgn_primary_dot_constant
     rb = "a.B = 1"
     pt = s(:attrasgn, s(:call, nil, :a), :"B=", s(:lit, 1))


### PR DESCRIPTION
Makes the following raise a SyntaxError:

```ruby
class Foo
  BEGIN {
    bar
  }
end
```