### PR TITLE
Fix line numbers for BEGIN block

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -112,7 +112,9 @@ rule
                     }
                     begin_block
                     {
-                      _, _, block = val
+                      (_, lineno), _, block = val
+                      block.line(lineno)
+                      block[1].line(lineno)
                       result = block
                     }
 

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -883,6 +883,15 @@ module TestRubyParserShared
     assert_parse_line rb, pt, 1
   end
 
+  def test_parse_line_preexe
+    rb = "BEGIN {\nfoo\n}"
+    pt = s(:iter,
+           s(:preexe).line(1), 0,
+           s(:call, nil, :foo).line(2)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
   def test_parse_line_rescue
     rb = "begin\n a\n rescue\n b\n rescue\n c\n end\n"
     pt = s(:rescue,


### PR DESCRIPTION
The current behavior is (with VERBOSE=true):

```
RubyParser.for_current_ruby.parse("BEGIN {\nfoo\n}")
# => s(:iter, s(:preexe).line(3), 0, s(:call, nil, :foo).line(2)).line(3)
```

Here, the `s(:preexe)` and `s(:iter ..)` both get line number 3, instead of 1.