### PR TITLE
Fix line numbering for ranges

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -766,18 +766,18 @@ rule
                     {
                       v1, v2 = val[0], val[2]
                       if v1.node_type == :lit and v2.node_type == :lit and Integer === v1.last and Integer === v2.last then
-                        result = s(:lit, (v1.last)..(v2.last))
+                        result = s(:lit, (v1.last)..(v2.last)).line v1.line
                       else
-                        result = s(:dot2, v1, v2)
+                        result = s(:dot2, v1, v2).line v1.line
                       end
                     }
                 | arg tDOT3 arg
                     {
                       v1, v2 = val[0], val[2]
                       if v1.node_type == :lit and v2.node_type == :lit and Integer === v1.last and Integer === v2.last then
-                        result = s(:lit, (v1.last)...(v2.last))
+                        result = s(:lit, (v1.last)...(v2.last)).line v1.line
                       else
-                        result = s(:dot3, v1, v2)
+                        result = s(:dot3, v1, v2).line v1.line
                       end
                     }
 #if V >= 26
@@ -785,13 +785,13 @@ rule
                     {
                       v1, v2 = val[0], nil
 
-                      result = s(:dot2, v1, v2)
+                      result = s(:dot2, v1, v2).line v1.line
                     }
                 | arg tDOT3
                     {
                       v1, v2 = val[0], nil
 
-                      result = s(:dot3, v1, v2)
+                      result = s(:dot3, v1, v2).line v1.line
                     }
 #endif
                 | arg tPLUS arg

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -830,6 +830,26 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_parse_line_dot2
+    rb = "0..4\na..b\nc"
+    pt = s(:block,
+           s(:lit, 0..4).line(1),
+           s(:dot2, s(:call, nil, :a).line(2), s(:call, nil, :b).line(2)).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
+  def test_parse_line_dot3
+    rb = "0...4\na...b\nc"
+    pt = s(:block,
+           s(:lit, 0...4).line(1),
+           s(:dot3, s(:call, nil, :a).line(2), s(:call, nil, :b).line(2)).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
   def test_parse_line_hash_lit
     rb = "{\n:s1 => 1,\n}"
     pt = s(:hash,
@@ -4048,6 +4068,27 @@ class TestRubyParserV26 < RubyParserTestCase
 
     self.processor = RubyParser::V26.new
   end
+
+  def test_parse_line_dot2_open
+    rb = "0..\n; a..\n; c"
+    pt = s(:block,
+           s(:dot2, s(:lit, 0).line(1), nil).line(1),
+           s(:dot2, s(:call, nil, :a).line(2), nil).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
+  def test_parse_line_dot3_open
+    rb = "0...\n; a...\n; c"
+    pt = s(:block,
+           s(:dot3, s(:lit, 0).line(1), nil).line(1),
+           s(:dot3, s(:call, nil, :a).line(2), nil).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
 end
 
 RubyParser::VERSIONS.each do |klass|


### PR DESCRIPTION
Ranges would pick up the lexer line number, which can already be on the next line. This change fixes this by using the line number of the range start.