### PR TITLE
Fix several line numbering issues

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -759,7 +759,7 @@ rule
                     {
                       v1, v2 = val[0], val[2]
                       if v1.node_type == :lit and v2.node_type == :lit and Integer === v1.last and Integer === v2.last then
-                        result = s(:lit, (v1.last)..(v2.last))
+                        result = s(:lit, (v1.last)..(v2.last)).line v1.line
                       else
                         result = s(:dot2, v1, v2)
                       end
@@ -768,7 +768,7 @@ rule
                     {
                       v1, v2 = val[0], val[2]
                       if v1.node_type == :lit and v2.node_type == :lit and Integer === v1.last and Integer === v2.last then
-                        result = s(:lit, (v1.last)...(v2.last))
+                        result = s(:lit, (v1.last)...(v2.last)).line v1.line
                       else
                         result = s(:dot3, v1, v2)
                       end

--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -615,9 +615,6 @@ module RubyParserStuff
       end
     end
 
-    line = result.grep(Sexp).map(&:line).compact.min
-    result.line = line if line
-
     result
   end
 
@@ -1268,6 +1265,8 @@ module RubyParserStuff
 
   def s(*args)
     result = Sexp.new(*args)
+    line = result.grep(Sexp).map(&:line).compact.min
+    result.line = line if line
     result.line ||= lexer.lineno if lexer.ss          # otherwise...
     result.file = self.file
     result

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -830,6 +830,26 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_parse_line_dot2
+    rb = "0..4\na..b\nc"
+    pt = s(:block,
+           s(:lit, 0..4).line(1),
+           s(:dot2, s(:call, nil, :a).line(2), s(:call, nil, :b).line(2)).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
+  def test_parse_line_dot3
+    rb = "0...4\na...b\nc"
+    pt = s(:block,
+           s(:lit, 0...4).line(1),
+           s(:dot3, s(:call, nil, :a).line(2), s(:call, nil, :b).line(2)).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
   def test_parse_line_hash_lit
     rb = "{\n:s1 => 1,\n}"
     pt = s(:hash,
@@ -985,6 +1005,17 @@ module TestRubyParserShared
            s(:true).line(1))
 
     assert_parse rb, pt
+  end
+
+  def test_parse_line_to_ary
+    rb = "a, b = c\nd"
+    pt = s(:block,
+           s(:masgn,
+             s(:array, s(:lasgn, :a).line(1), s(:lasgn, :b).line(1)).line(1),
+             s(:to_ary, s(:call, nil, :c).line(1)).line(1)).line(1),
+           s(:call, nil, :d).line(2)).line(1)
+
+    assert_parse_line rb, pt, 1
   end
 
   def test_parse_line_trailing_newlines
@@ -4049,6 +4080,27 @@ class TestRubyParserV26 < RubyParserTestCase
 
     self.processor = RubyParser::V26.new
   end
+
+  def test_parse_line_dot2_open
+    rb = "0..\n; a..\n; c"
+    pt = s(:block,
+           s(:dot2, s(:lit, 0).line(1), nil).line(1),
+           s(:dot2, s(:call, nil, :a).line(2), nil).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
+  def test_parse_line_dot3_open
+    rb = "0...\n; a...\n; c"
+    pt = s(:block,
+           s(:dot3, s(:lit, 0).line(1), nil).line(1),
+           s(:dot3, s(:call, nil, :a).line(2), nil).line(2),
+           s(:call, nil, :c).line(3)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
 end
 
 RubyParser::VERSIONS.each do |klass|


### PR DESCRIPTION
- Fix line numbering for range literals
- Fix line numbering for right-hand side of multiple assignment

This changes the implementation of `s()` to inherit line numbers from its children if possible.