### PR TITLE
Fix line numbers for END block

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -226,11 +226,13 @@ rule
                     }
                 | klEND tLCURLY compstmt tRCURLY
                     {
+                      (_, lineno), _, stmt, _ = val
                       if (self.in_def || self.in_single > 0) then
                         debug20 3
                         yyerror "END in method; use at_exit"
                       end
-                      result = new_iter s(:postexe), 0, val[2]
+                      iter = new_iter s(:postexe).line(lineno), 0, stmt
+                      result = iter.line lineno
                     }
                 | command_asgn
                 | mlhs tEQL command_call

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -937,6 +937,15 @@ module TestRubyParserShared
     assert_parse_line rb, pt, 1
   end
 
+  def test_parse_line_postexe
+    rb = "END {\nfoo\n}"
+    pt = s(:iter,
+           s(:postexe).line(1), 0,
+           s(:call, nil, :foo).line(2)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
   def test_parse_line_preexe
     rb = "BEGIN {\nfoo\n}"
     pt = s(:iter,


### PR DESCRIPTION
Similar to #287:

```ruby
>> ENV['VERBOSE'] = 'true'
#=> "true"
>> RubyParser.for_current_ruby.parse("END {\nfoo\n}")
#=> s(:iter, s(:postexe).line(3), 0, s(:call, nil, :foo).line(2)).line(3)
```

The `s(:postexe)` and `s(:iter ..)` should both have `line(1)`.