### PR TITLE
Fix line numbering for right-hand side of multiple assignment

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -805,7 +805,7 @@ module RubyParserStuff
 
   def new_masgn_arg rhs, wrap = false
     rhs = value_expr(rhs)
-    rhs = s(:to_ary, rhs) if wrap # HACK: could be array if lhs isn't right
+    rhs = s(:to_ary, rhs).line rhs.line if wrap # HACK: could be array if lhs isn't right
     rhs
   end
 
@@ -813,7 +813,11 @@ module RubyParserStuff
     _, ary = lhs
 
     rhs = value_expr(rhs)
-    rhs = ary ? s(:to_ary, rhs) : s(:array, rhs) if wrap
+    if wrap
+      line = rhs.line
+      rhs = ary ? s(:to_ary, rhs) : s(:array, rhs)
+      rhs = rhs.line line
+    end
 
     lhs.delete_at 1 if ary.nil?
     lhs << rhs

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -987,6 +987,17 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_parse_line_to_ary
+    rb = "a, b = c\nd"
+    pt = s(:block,
+           s(:masgn,
+             s(:array, s(:lasgn, :a).line(1), s(:lasgn, :b).line(1)).line(1),
+             s(:to_ary, s(:call, nil, :c).line(1)).line(1)).line(1),
+           s(:call, nil, :d).line(2)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
   def test_parse_line_trailing_newlines
     rb = "a \nb"
     pt = s(:block,


### PR DESCRIPTION
Together with #288, supersedes #289.

```ruby
>> ENV['VERBOSE'] = 'true' #=> "true"
>> RubyParser.for_current_ruby.parse("a, b = c\nd")
# => s(:block,
#      s(:masgn,
#        s(:array, s(:lasgn, :a).line(1), s(:lasgn, :b).line(1)).line(1),
#        s(:to_ary, s(:call, nil, :c).line(1)).line(2)).line(1),
#      s(:call, nil, :d).line(2)).line(1)
```

Here, `s(:to_ary, s(:call, nil, :c))` has line number 2, but it should be 1. This is fixed in two places due to different target Ruby versions.