### PR TITLE
Fix line numbering for method arguments without parentheses

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -831,6 +831,8 @@ module RubyParserStuff
     (_, line), name, _, args, body, nil_body_line, * = val
     body ||= s(:nil).line nil_body_line
 
+    args.line line
+
     result = s(:defn, name.to_sym, args).line line
 
     if body then

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -1514,6 +1514,13 @@ module TestRubyParserShared
     assert_equal 2, c.line,   "call should have line number"
   end
 
+  def test_parse_line_defn_no_parens_args
+    rb = "def f a\nend"
+    pt = s(:defn, :f, s(:args, :a).line(1), s(:nil).line(2)).line(1)
+
+    assert_parse_line rb, pt, 1
+  end
+
   def test_parse_line_defn_complex
     rb = "def x(y)\n  p(y)\n  y *= 2\n  return y;\nend" # TODO: remove () & ;
     pt = s(:defn, :x, s(:args, :y),
@@ -1530,7 +1537,7 @@ module TestRubyParserShared
   end
 
   def test_parse_line_defn_no_parens
-    pt = s(:defn, :f, s(:args), s(:nil))
+    pt = s(:defn, :f, s(:args).line(1), s(:nil)).line(1)
 
     rb = "def f\nend"
     assert_parse_line rb, pt, 1


### PR DESCRIPTION
The line number for method arguments without parentheses is currently one more than it should be:

```ruby
>> ENV['VERBOSE'] = 'true'
=> "true"
>> RubyParser.for_current_ruby.parse("def f(a)\nend")
=> s(:defn, :f, s(:args, :a).line(1), s(:nil).line(2)).line(1)
>> RubyParser.for_current_ruby.parse("def f a\nend")
=> s(:defn, :f, s(:args, :a).line(2), s(:nil).line(2)).line(1)
```

The line number for `s(:args, :a)` should be 1 in both cases.

This change fixes that problem.