### PR TITLE
Parse interpolation in heredocs like strings

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -177,10 +177,15 @@ class RubyLexer
 
     if expand then
       case
-      when scan(/#[$@]/) then
-        ss.pos -= 1 # FIX omg stupid
+      when scan(/#(?=\$(-.|[a-zA-Z_0-9~\*\$\?!@\/\\;,\.=:<>\"\&\`\'+]))/) then
+        # TODO: !ISASCII
+        # ?! see parser_peek_variable_name
+        return :tSTRING_DVAR, matched
+      when scan(/#(?=\@\@?[a-zA-Z_])/) then
+        # TODO: !ISASCII
         return :tSTRING_DVAR, matched
       when scan(/#[{]/) then
+        self.command_start = true
         return :tSTRING_DBEG, matched
       when scan(/#/) then
         string_buffer << "#"

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -1109,11 +1109,11 @@ class TestRubyLexer < Minitest::Test
                 :tEQL,            "=",     EXPR_BEG,
                 :tSTRING_BEG,     "\"",    EXPR_BEG,
                 :tSTRING_CONTENT, "#x a ", EXPR_BEG,
-                :tSTRING_DVAR,    "\#@",   EXPR_BEG,
+                :tSTRING_DVAR,    "#",    EXPR_BEG,
                 :tSTRING_CONTENT, "@a b ", EXPR_BEG, # HUH?
-                :tSTRING_DVAR,    "\#$",   EXPR_BEG,
+                :tSTRING_DVAR,    "#",   EXPR_BEG,
                 :tSTRING_CONTENT, "$b c ", EXPR_BEG, # HUH?
-                :tSTRING_DVAR,    "\#@",   EXPR_BEG,
+                :tSTRING_DVAR,    "#",   EXPR_BEG,
                 :tSTRING_CONTENT, "@@d ",  EXPR_BEG, # HUH?
                 :tSTRING_DBEG,    "\#{",   EXPR_BEG,
                 :tSTRING_CONTENT, "3} \n", EXPR_BEG,

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -900,6 +900,13 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_heredoc_with_not_global_interpolation
+    rb = "<<-HEREDOC\n#${\nHEREDOC"
+    pt = s(:str, "\#${\n")
+
+    assert_parse rb, pt
+  end
+
   def test_i_fucking_hate_line_numbers
     rb = <<-END.gsub(/^ {6}/, "")
       if true


### PR DESCRIPTION
RubyParser misidentifies `#${` as global variable interpolation in heredocs:

```
2.7.0 :002'> RubyParser.new.parse '<<-HEREDOC
2.7.0 :003'> #${this is not actually interpolation!}
2.7.0 :004 > HEREDOC'
Traceback (most recent call last):
       16: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_parser.rb:33:in `process'
       15: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_parser.rb:33:in `each'
       14: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_parser.rb:36:in `block in process'
       13: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_parser_extras.rb:1285:in `process'
       12: from /home/justin/.rvm/rubies/ruby-2.7.0/lib/ruby/2.7.0/timeout.rb:110:in `timeout'
       11: from /home/justin/.rvm/rubies/ruby-2.7.0/lib/ruby/2.7.0/timeout.rb:33:in `catch'
       10: from /home/justin/.rvm/rubies/ruby-2.7.0/lib/ruby/2.7.0/timeout.rb:33:in `catch'
        9: from /home/justin/.rvm/rubies/ruby-2.7.0/lib/ruby/2.7.0/timeout.rb:33:in `block in catch'
        8: from /home/justin/.rvm/rubies/ruby-2.7.0/lib/ruby/2.7.0/timeout.rb:95:in `block in timeout'
        7: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_parser_extras.rb:1297:in `block in process'
        6: from (eval):3:in `do_parse'
        5: from (eval):3:in `_racc_do_parse_c'
        4: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_parser_extras.rb:1262:in `next_token'
        3: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_lexer.rex.rb:334:in `next_token'
        2: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_lexer.rb:598:in `process_gvar_oddity'
        1: from /home/justin/.rvm/gems/ruby-2.7.0@brakeman/gems/ruby_parser-3.14.2/lib/ruby_lexer.rb:990:in `rb_compile_error'
RubyParser::SyntaxError ("${" is not allowed as a global variable name. near line 1: "this is not actually interpolation!}")
```

Ruby doesn't mind:

```
2.7.0 :005"> <<-HEREDOC
2.7.0 :006"> #${this is not actually interpolation!}
2.7.0 :007 > HEREDOC
 => "\#${this is not actually interpolation!}\n"
```

But also RubyParser only has a problem with this in heredocs:

```
2.7.0 :008 > RubyParser.new.parse '"#${this is not actually interpolation!}"'
 => s(:str, "\#${this is not actually interpolation!}")
```

So I straight copy-pasted the code from `parse_string` that I believe handles the same thing. I recognize this is a terrible way to "write" code.

From my testing, this did not introduce any regressions.