### PR TITLE
Allow processing of string literals with invalid encoding

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -876,6 +876,16 @@ class RubyLexer
     return token
   end
 
+  def process_string_literal text
+    content = text[1..-2]
+    unescaped = begin
+      content.gsub(ESC) { unescape $1 }
+    rescue Encoding::CompatibilityError
+      content.force_encoding(Encoding::ASCII_8BIT).gsub(ESC) { unescape $1 }
+    end
+    result EXPR_END, :tSTRING, unescaped
+  end
+
   def process_symbol text
     symbol = possibly_escape_string text, /^:"/
 

--- a/lib/ruby_lexer.rex
+++ b/lib/ruby_lexer.rex
@@ -62,7 +62,7 @@ rule
 |               /\=(?=begin\b)/         { result arg_state, TOKENS[text], text }
 
 ruby22_label?   /\"#{SIMPLE_STRING}\":/o process_label
-                /\"(#{SIMPLE_STRING})\"/o { result EXPR_END, :tSTRING, text[1..-2].gsub(ESC) { unescape $1 } }
+                /\"(#{SIMPLE_STRING})\"/o process_string_literal
                 /\"/                    { string STR_DQUOTE; result nil, :tSTRING_BEG, text }
 
                 /\@\@?\d/               { rb_compile_error "`#{text}` is not allowed as a variable name" }

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -1,6 +1,4 @@
-# encoding: US-ASCII
-
-# TODO: work this out
+# encoding: UTF-8
 
 require "minitest/autorun"
 require "ruby_lexer"
@@ -84,6 +82,8 @@ class TestRubyLexer < Minitest::Test
       assert_in_epsilon value, act_value, 0.001, msg
     when NilClass then
       assert_nil act_value, msg
+    when String then
+      assert_equal value, act_value.dup.force_encoding(Encoding::UTF_8), msg
     else
       assert_equal value, act_value, msg
     end
@@ -98,7 +98,7 @@ class TestRubyLexer < Minitest::Test
 
   def assert_read_escape expected, input
     @lex.ss.string = input.dup
-    assert_equal expected, @lex.read_escape.b, input
+    assert_equal expected, @lex.read_escape.dup.force_encoding(Encoding::UTF_8), input
   end
 
   def assert_read_escape_bad input # TODO: rename refute_read_escape

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -312,6 +312,11 @@ class TestRubyLexer < Minitest::Test
     assert_lex3(s.dup, nil, :tIVAR, s.dup, EXPR_END)
   end
 
+  def test_invalid_enocoding_string_literal
+    s = "\"\\xBA\\xBBƮ\\xC1\\xF7\\xB1\\xB8\""
+    assert_lex3(s.dup, nil, :tSTRING, "\xBA\xBBƮ\xC1\xF7\xB1\xB8", EXPR_END)
+  end
+
   def test_why_does_ruby_hate_me?
     assert_lex3("\"Nl%\\000\\000A\\000\\999\"", # you should be ashamed
                 nil,


### PR DESCRIPTION
Currently, `ruby_parser` cannot unescape string literals with invalid encoding (in my tests, strings with unicode and binary characters). When scanning a file like this:
```ruby
class ValidatorTest < Minitest::Test
  def test_reject_malformed_string
    malformed_string = "\xBA\xBBƮ\xC1\xF7\xB1\xB8"
    refute_predicate Validator.new(malformed_string), :valid?
  end
end
```
The stack-trace ends at  ```ruby_parser-3.14.1/lib/ruby_lexer.rex.rb:163:in `gsub': incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)```.  I've done two things to fix this:

1. Make the lexer test case file UTF-8. This is needed to add a weirdly encoded string test.
2. Change the rex template to parse literals with `#process_string_literal`.  It essentially does the same thing with a fallback to encode the unquoted literal content as ASCII-8BIT.