### PR TITLE
Bumped require_ruby_version to < 4 (trunk = 3.1)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ Hoe.spec "ruby_parser" do
   dependency "rake", "< 11", :developer
   dependency "oedipus_lex", "~> 2.5", :developer
 
-  require_ruby_version [">= 2.1", "< 3.1"]
+  require_ruby_version [">= 2.1", "< 4.0"]
 
   if plugin? :perforce then     # generated files
     V2.each do |n|


### PR DESCRIPTION
Same issue than with Minitest. We can't test our project against ruby-head anymore because of ruby_parser requirements.

Ref: https://github.com/seattlerb/minitest/commit/8e55b9b07b31efe6734a7aff81df0535c15000c2

cc @zenspider 