### PR TITLE
First cut at supporting argument forwarding

### DIFF
--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1064,6 +1064,12 @@ rule
                       _, args, _ = val
                       result = args
                     }
+#if V >= 27
+                | tLPAREN2 args_forward rparen
+                    {
+                      result = call_args [s(:forward_args).line(lexer.lineno)]
+                    }
+#endif
 
   opt_paren_args: none
                 | paren_args
@@ -2364,6 +2370,14 @@ keyword_variable: kNIL      { result = s(:nil).line lexer.lineno }
                       self.lexer.lex_state = EXPR_BEG
                       self.lexer.command_start = true
                     }
+#if V >= 27
+                | tLPAREN2 args_forward rparen
+                    {
+                      result = s(:args, s(:forward_args)).line lexer.lineno
+                      self.lexer.lex_state = EXPR_BEG
+                      self.lexer.command_start = true
+                    }
+#endif
                 |   {
                       result = self.in_kwarg
                       self.in_kwarg = true
@@ -2462,6 +2476,8 @@ keyword_variable: kNIL      { result = s(:nil).line lexer.lineno }
                     {
                       result = args val
                     }
+
+       args_forward: tBDOT3
 
        f_bad_arg: tCONSTANT
                     {

--- a/lib/ruby_parser.yy
+++ b/lib/ruby_parser.yy
@@ -1067,6 +1067,12 @@ rule
 #if V >= 27
                 | tLPAREN2 args_forward rparen
                     {
+                      if (!self.lexer.is_local_id(:"*") ||
+                            !self.lexer.is_local_id(:"**") ||
+                            !self.lexer.is_local_id(:"&")) then
+
+                        yyerror("Invalid argument forwarding")
+                      end
                       result = call_args [s(:forward_args).line(lexer.lineno)]
                     }
 #endif
@@ -2373,6 +2379,13 @@ keyword_variable: kNIL      { result = s(:nil).line lexer.lineno }
 #if V >= 27
                 | tLPAREN2 args_forward rparen
                     {
+                      args_rest = :"*"
+                      kwargs_rest = :"**"
+                      block_fwd = :"&"
+                      self.env[args_rest] = :lvar
+                      self.env[kwargs_rest] = :lvar
+                      self.env[block_fwd] = :lvar
+
                       result = s(:args, s(:forward_args)).line lexer.lineno
                       self.lexer.lex_state = EXPR_BEG
                       self.lexer.command_start = true
@@ -2627,6 +2640,7 @@ keyword_variable: kNIL      { result = s(:nil).line lexer.lineno }
                 | kwrest_mark
                     {
                       result = :"**"
+                      self.env[result] = :lvar
                     }
 
 #if V == 20

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -4464,6 +4464,20 @@ class TestRubyParserV27 < RubyParserTestCase
 
     assert_parse_line rb, pt, 1
   end
+
+  def test_forward_args
+    rb = "def a(...); b(...); end"
+    pt = s(:defn, :a, s(:args, s(:forward_args)),
+          s(:call, nil, :b, s(:forward_args)))
+
+    assert_parse_line rb, pt, 1
+  end
+
+  def test_forward_args_invalid
+    rb = "b(...)"
+
+    assert_syntax_error rb, ""
+  end
 end
 
 

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -4473,25 +4473,25 @@ class TestRubyParserV27 < RubyParserTestCase
     assert_parse_line rb, pt, 1
   end
 
-  def test_forward_args_invalid
+  def test_forward_args_outside_method_definition
     rb = "b(...)"
 
     assert_syntax_error rb, "Invalid argument forwarding"
   end
 
-  def test_forward_args_idrest
+  def test_forward_args_only_idfwd_rest
     rb = "def a(*); b(...); end"
 
     assert_syntax_error rb, "Invalid argument forwarding"
   end
 
-  def test_forward_args_idkwrest
+  def test_forward_args_only_idfwd_kwrest
     rb = "def a(**); b(...); end"
 
     assert_syntax_error rb, "Invalid argument forwarding"
   end
 
-  def test_forward_args_idrest_idkwrest
+  def test_forward_args_no_fwd_block
     rb = "def a(*, **); b(...); end"
 
     assert_syntax_error rb, "Invalid argument forwarding"

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -4476,7 +4476,25 @@ class TestRubyParserV27 < RubyParserTestCase
   def test_forward_args_invalid
     rb = "b(...)"
 
-    assert_syntax_error rb, ""
+    assert_syntax_error rb, "Invalid argument forwarding"
+  end
+
+  def test_forward_args_idrest
+    rb = "def a(*); b(...); end"
+
+    assert_syntax_error rb, "Invalid argument forwarding"
+  end
+
+  def test_forward_args_idkwrest
+    rb = "def a(**); b(...); end"
+
+    assert_syntax_error rb, "Invalid argument forwarding"
+  end
+
+  def test_forward_args_idrest_idkwrest
+    rb = "def a(*, **); b(...); end"
+
+    assert_syntax_error rb, "Invalid argument forwarding"
   end
 end
 


### PR DESCRIPTION
Adds support for argument forwarding from Ruby 2.7.

However, it needs to be a syntax error if the triple-dot argument forwarding is used anywhere but inside a method definition that sets argument forwarding (i.e., `def x(...); end`).

Looks like in MRI they set some special argument variables to do the forwarding and [check for their existence in the parser](https://github.com/ruby/ruby/blob/ruby_2_7/parse.y#L2421-L2429). (The current parser has abstracted this out into helper methods.)

Open to suggestions on how/where to track that information.