### PR TITLE
Use a current version of Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ Hoe.spec "ruby_parser" do
   license "MIT"
 
   dependency "sexp_processor", "~> 4.9"
-  dependency "rake", "< 11", :developer
+  dependency "rake", "~> 13.0", :developer
   dependency "oedipus_lex", "~> 2.5", :developer
 
   require_ruby_version [">= 2.1", "< 4"]


### PR DESCRIPTION
Rake 13.x is bundled with Ruby now which means using an older version is a pain.

I didn't notice any obvious incompatibilities.