### PR TITLE
Fix heredoc dedenting in the presence of empty lines

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -466,7 +466,7 @@ module RubyParserStuff
         end
       else
         warn "unprocessed: %p" % [s]
-      end.map { |l| whitespace_width l[/^[ \t]*/] }
+      end.map { |l| whitespace_width l.chomp }
     }.compact.min
   end
 
@@ -1594,6 +1594,8 @@ module RubyParserStuff
 
     if remove_width then
       line[idx..-1]
+    elsif line[idx].nil?
+      nil
     else
       col
     end

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -3990,6 +3990,27 @@ module TestRubyParserShared23Plus
     assert_parse rb, pt
   end
 
+  def test_heredoc_squiggly_blank_lines
+    rb = "a = <<~EOF\n  x\n\n  z\nEOF\n\n"
+    pt = s(:lasgn, :a, s(:str, "x\n\nz\n"))
+
+    assert_parse rb, pt
+  end
+
+  def test_heredoc_squiggly_visually_blank_lines
+    rb = "a = <<~EOF\n  x\n \n  z\nEOF\n\n"
+    pt = s(:lasgn, :a, s(:str, "x\n\nz\n"))
+
+    assert_parse rb, pt
+  end
+
+  def test_heredoc_squiggly_empty
+    rb = "<<~A\nA"
+    pt = s(:str, "")
+
+    assert_parse rb, pt
+  end
+
   def test_integer_with_if_modifier
     rb = "1_234if true"
     pt = s(:if, s(:true), s(:lit, 1234), nil)


### PR DESCRIPTION
This fixes parsing of squiggly heredocs when some lines are blank. Such lines should not count toward the whitespace width.

E.g.,
```ruby
<<~FOO
  bar

  baz
FOO
```

This should be parsed as `"bar\n\nbaz\n".