### PR TITLE
Fixes endless method with noargs

### DIFF
--- a/lib/ruby3_parser.yy
+++ b/lib/ruby3_parser.yy
@@ -3039,6 +3039,9 @@ keyword_variable: kNIL      { result = s(:nil).line lexer.lineno }
 
 f_opt_paren_args: f_paren_args
                 | none
+		    {
+		      result = end_args val
+		    }
 
     f_paren_args: tLPAREN2 f_args rparen
                     {

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -5223,6 +5223,22 @@ module TestRubyParserShared30Plus
     assert_parse rb, pt
   end
 
+  def test_defn_oneliner_noargs_parentheses
+    rb = "def exec() = system"
+    pt = s(:defn, :exec, s(:args).line(1),
+            s(:call, nil, :system).line(1))
+
+    assert_parse rb, pt
+  end
+
+  def test_defn_oneliner_noargs
+    rb = "def exec = system"
+    pt = s(:defn, :exec, s(:args).line(1),
+            s(:call, nil, :system).line(1))
+
+    assert_parse rb, pt
+  end
+
   def test_defn_oneliner_rescue
     rb = "def exec(cmd)\n  system(cmd)\nrescue\n  nil\nend\n"
     pt = s(:defn, :exec, s(:args, :cmd),


### PR DESCRIPTION
Fixed an issue where the parsed result was different between
the endless method with no arguments and the empty `()` case.

refs https://github.com/presidentbeef/brakeman/pull/1648#issuecomment-962698048