### PR TITLE
Add comments to endless defn and defs

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -994,6 +994,8 @@ module RubyParserStuff
     local_pop in_def
     endless_method_name result
 
+    result.comments = self.comments.pop
+
     result
   end
 
@@ -1013,6 +1015,8 @@ module RubyParserStuff
     self.in_single -= 1
     local_pop in_def
     endless_method_name result
+
+    result.comments = self.comments.pop
 
     result
   end

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -5272,6 +5272,15 @@ module TestRubyParserShared30Plus
     assert_parse rb, pt.deep_each { |s| s.line = 1 }
   end
 
+  def test_defn_oneliner_comment
+    p = RubyParser.new
+    rb = "# blah\ndef exec(cmd) = system(cmd)"
+    sexp = p.parse rb
+
+    assert_equal :defn, sexp.sexp_type
+    assert_equal "# blah\n", sexp.comments
+  end
+
   def test_defs_oneliner
     rb = "def self.exec(cmd) = system(cmd)"
     pt = s(:defs, s(:self), :exec, s(:args, :cmd),
@@ -5293,6 +5302,15 @@ module TestRubyParserShared30Plus
 
     rb = "def self.exec(cmd) = system(cmd) rescue nil"
     assert_parse rb, pt.deep_each { |s| s.line = 1 }
+  end
+
+  def test_defs_oneliner_comment
+    p = RubyParser.new
+    rb = "# blah\ndef self.exec(cmd) = system(cmd)"
+    sexp = p.parse rb
+
+    assert_equal :defs, sexp.sexp_type
+    assert_equal "# blah\n", sexp.comments
   end
 
   def test_defn_oneliner_setter


### PR DESCRIPTION
Unlike regular defn and defs nodes, endless defn and defs nodes did not get comments attached. This change fixes that.
