### PR TITLE
Fix dedenting when heredoc has only empty line and interpolation

### DIFF
--- a/lib/ruby_parser_extras.rb
+++ b/lib/ruby_parser_extras.rb
@@ -471,7 +471,7 @@ module RubyParserStuff
         end
       else
         warn "unprocessed: %p" % [s]
-      end.map { |l| whitespace_width l.chomp }
+      end.map { |l| whitespace_width l }
     }.compact.min
   end
 
@@ -1651,7 +1651,7 @@ module RubyParserStuff
 
     if remove_width then
       line[idx..-1]
-    elsif line[idx].nil?
+    elsif line[idx] == "\n"
       nil
     else
       col

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -4270,6 +4270,21 @@ module TestRubyParserShared23Plus
     assert_parse rb, pt
   end
 
+  def test_heredoc_squiggly_blank_line_plus_interpolation
+    rb = "a = foo(<<~EOF.chop)\n\n    #\{bar}baz\n  EOF"
+    pt = s(:lasgn, :a,
+           s(:call,
+             nil,
+             :foo,
+             s(:call,
+               s(:dstr, "\n",
+                 s(:evstr, s(:call, nil, :bar).line(3)).line(3),
+                 s(:str, "baz\n").line(3)).line(1),
+               :chop).line(1)).line(1)).line(1)
+
+    assert_parse rb, pt
+  end
+
   def test_integer_with_if_modifier
     rb = "1_234if true"
     pt = s(:if, s(:true), s(:lit, 1234), nil)


### PR DESCRIPTION
This fixes a bug for squiggly heredocs that consist of an empty line followed only by lines starting with interpolation. For those cases, the initial string literal for the :dstr node would be "0" instead of the correct "\n".
