### PR TITLE
Fix dsym unescaping

### DIFF
--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -232,7 +232,12 @@ class RubyLexer
     content = match[1]
 
     if text =~ check then
-      content.gsub(ESC) { unescape $1 }
+      str = content.gsub(ESC) { unescape($1).b.force_encoding Encoding::UTF_8 }
+      if str.valid_encoding?
+        str
+      else
+        str.b
+      end
     else
       content.gsub(/\\\\/, "\\").gsub(/\\\'/, "'")
     end

--- a/lib/ruby_lexer.rb
+++ b/lib/ruby_lexer.rb
@@ -232,12 +232,7 @@ class RubyLexer
     content = match[1]
 
     if text =~ check then
-      str = content.gsub(ESC) { unescape($1).b.force_encoding Encoding::UTF_8 }
-      if str.valid_encoding?
-        str
-      else
-        str.b
-      end
+      unescape_string content
     else
       content.gsub(/\\\\/, "\\").gsub(/\\\'/, "'")
     end
@@ -595,9 +590,7 @@ class RubyLexer
     orig_line = lineno
     self.lineno += text.count("\n")
 
-    str = text[1..-2]
-      .gsub(ESC) { unescape($1).b.force_encoding Encoding::UTF_8 }
-    str = str.b unless str.valid_encoding?
+    str = unescape_string text[1..-2]
 
     result EXPR_END, :tSTRING, str, orig_line
   end
@@ -819,6 +812,15 @@ class RubyLexer
     else
       # TODO: warn_balanced("**", "argument prefix");
       fallback
+    end
+  end
+
+  def unescape_string str
+    str = str.gsub(ESC) { unescape($1).b.force_encoding Encoding::UTF_8 }
+    if str.valid_encoding?
+      str
+    else
+      str.b
     end
   end
 

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -3009,6 +3009,22 @@ class TestRubyLexer < Minitest::Test
                 :tSTRING_END,     "\"",     EXPR_LIT)
   end
 
+  def test_yylex_symbol_double_escape_octal
+    assert_lex3(":\"Variet\\303\\240\"", nil, :tSYMBOL, "Varietà", EXPR_LIT)
+
+    input = ":\"Variet\\303\\240\""
+    setup_lexer input
+
+    adv = @lex.next_token
+    act_token, act_value = adv
+    act_value = act_value.first
+
+    assert_equal :tSYMBOL, act_token
+    assert_match EXPR_LIT, @lex.lex_state
+    # Force comparison of encodings
+    assert_equal "Varietà", act_value
+  end
+
   def test_yylex_symbol_single
     assert_lex3(":'symbol'",
                 nil,

--- a/test/test_ruby_lexer.rb
+++ b/test/test_ruby_lexer.rb
@@ -3010,10 +3010,7 @@ class TestRubyLexer < Minitest::Test
   end
 
   def test_yylex_symbol_double_escape_octal
-    assert_lex3(":\"Variet\\303\\240\"", nil, :tSYMBOL, "Varietà", EXPR_LIT)
-
-    input = ":\"Variet\\303\\240\""
-    setup_lexer input
+    setup_lexer ":\"Variet\\303\\240\""
 
     adv = @lex.next_token
     act_token, act_value = adv

--- a/test/test_ruby_parser.rb
+++ b/test/test_ruby_parser.rb
@@ -826,6 +826,13 @@ module TestRubyParserShared
     assert_parse rb, pt
   end
 
+  def test_dsym_esc_to_sym
+    rb = ':"Variet\303\240"'
+    pt = s(:lit, :Varietà)
+
+    assert_parse rb, pt
+  end
+
   def test_empty
     refute_parse ""
   end


### PR DESCRIPTION
This fixes the following issue in the parsing of dsyms with octal escape sequences:

```ruby
irb(main):005:0> RubyParser.for_current_ruby.parse  ":\"Variet\\303\\240\""
=> s(:lit, :"Variet\xC3\xA0")
irb(main):006:0> eval  ":\"Variet\\303\\240\""
=> :Varietà
```
