### PR TITLE
Update minimum version of sexp_processor

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ Hoe.spec "ruby_parser" do
 
   license "MIT"
 
-  dependency "sexp_processor", "~> 4.16"
+  dependency "sexp_processor", "~> 4.17"
   dependency "rake", [">= 10", "< 15"], :developer
   dependency "oedipus_lex", "~> 2.6", :developer
 


### PR DESCRIPTION
tests fail with 4.16.1, but passes with 4.17. Fixes #336 