### PR TITLE
Make racc an explicit runtime dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ Hoe.spec "ruby_parser" do
   # install racc` and move on. Revisit this ONLY once racc-compiler
   # gets split out.
 
-  dependency "racc", "~> 1.5", :developer
+  dependency "racc", "~> 1.5"
 
   require_ruby_version [">= 2.6", "< 4"]
 


### PR DESCRIPTION
👋 Hello! I am not sure if this is the right change but figured I'd put up a PR anyway. 

In Ruby 3.3, racc goes from a default gem to a bundled gem ([release page](https://www.ruby-lang.org/en/news/2023/12/11/ruby-3-3-0-rc1-released/)), making it behave like a normal gem. I believe we should explicitly require racc as a runtime dependency. 

We were seeing errors like these in libraries that uses ruby_parser on 3.3 that tries to load `racc/parser` but fails. 